### PR TITLE
Ящик скорпионов в карго

### DIFF
--- a/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_armory.yml
@@ -87,3 +87,13 @@
   cost: 4000
   category: cargoproduct-category-name-armory
   group: market
+
+- type: cargoProduct
+  id: CrateArmoryScorpion
+  icon:
+    sprite: _Sunrise/Objects/Weapons/Guns/SMGs/skorpion.rsi
+    state: icon
+  product: CrateArmoryScorpion
+  cost: 7500
+  category: cargoproduct-category-name-armory
+  group: market

--- a/Resources/Prototypes/_Sunrise/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Fills/Crates/armory.yml
@@ -121,3 +121,16 @@
     contents:
       - id: MagazineBoxRifle
         amount: 4
+
+- type: entity
+  id: CrateArmoryScorpion
+  parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
+  name: Scorpion Crate
+  description: Contains two Scorpion smg with four mags. Requires Armory access to open.
+  components:
+   - type: StorageFill
+     contents:
+     - id: WeaponSubMachineGunSkorpion
+       amount: 2
+     - id: MagazinePistolSubMachineGun
+       amount: 4


### PR DESCRIPTION

## Кратное описание
Ящик с двумя скорпионами и 4-мя магазинами к нему. 

## По какой причине
Попросили

**Changelog**

:cl: Prototype0308
- add: Добавлена возможность купить ящик с Scorpion.VZ за 7500



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
	- Добавлен новый грузовой ящик "Armory Scorpion", содержащий два пистолета-пулемёта Skorpion и четыре магазина. Ящик доступен для заказа через арсенал.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->