### PR TITLE
Оповещения голосом оповещающего

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.RoundEnd;
 using Content.Server.Screens.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
+using Content.Shared._Sunrise.TTS; // Sunrise-edit
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
@@ -263,7 +264,14 @@ namespace Content.Server.Communications
             msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author;
             if (comp.Global)
             {
-                _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color, announceVoice: comp.AnnounceVoice);
+                // Sunrise-start
+                var voice = comp.AnnounceVoice;
+                if (TryComp<TTSComponent>(message.Actor, out var ttsComponent))
+                {
+                    voice = ttsComponent.VoicePrototypeId;
+                }
+                // Sunrise-end
+                _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color, announceVoice: voice); // Sunrise-edit
 
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(message.Actor):player} has sent the following global announcement: {msg}");
                 return;


### PR DESCRIPTION
Теперь консоли связи кидают оповещения голосом того, кто делает оповещение. RP

:cl: pacable
- tweak: Оповещения с консолей связи производятся голосом того, кто написал оповещение.
