### PR TITLE
Исправление целей культа

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Content.Server._Sunrise.TraitorTarget;
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Ghost;
@@ -216,6 +217,8 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
 
         comp.AllowReEnteringBody = false;
         _transform.SetParent(ent, PausedMap.Value);
+        RaiseLocalEvent(ent, new CryostorageEnteredEvent());
+        RemCompDeferred<AntagTargetComponent>(ent);
         cryostorageComponent.StoredPlayers.Add(ent);
         Dirty(ent, comp);
         UpdateCryostorageUIState((cryostorageEnt.Value, cryostorageComponent));
@@ -347,4 +350,8 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             HandleEnterCryostorage((uid, containedComp), id);
         }
     }
+}
+
+public class CryostorageEnteredEvent
+{
 }

--- a/Content.Server/_Sunrise/BloodCult/BloodCultTargetComponent.cs
+++ b/Content.Server/_Sunrise/BloodCult/BloodCultTargetComponent.cs
@@ -1,0 +1,6 @@
+﻿namespace Content.Server._Sunrise.BloodCult;
+
+[RegisterComponent]
+public sealed partial class BloodCultTargetComponent : Component
+{
+}

--- a/Content.Server/_Sunrise/BloodCult/GameRule/BloodCultRuleComponent.cs
+++ b/Content.Server/_Sunrise/BloodCult/GameRule/BloodCultRuleComponent.cs
@@ -1,9 +1,10 @@
-﻿using Content.Shared._Sunrise.BloodCult;
+﻿using Content.Server._Sunrise.BloodCult.Runes.Systems;
+using Content.Shared._Sunrise.BloodCult;
 using Robust.Shared.Audio;
 
 namespace Content.Server._Sunrise.BloodCult.GameRule;
 
-[RegisterComponent, Access(typeof(BloodCultRuleSystem))]
+[RegisterComponent, Access(typeof(BloodCultRuleSystem), typeof(BloodCultSystem))]
 public sealed partial class BloodCultRuleComponent : Component
 {
     [DataField]
@@ -19,13 +20,13 @@ public sealed partial class BloodCultRuleComponent : Component
         new SoundPathSpecifier("/Audio/_Sunrise/BloodCult/blood_cult_greeting.ogg");
 
     [ViewVariables]
-    public List<EntityUid> CultTargets = new();
+    public readonly Dictionary<EntityUid, bool> CultTargets = new();
 
     [DataField]
     public int MaxTargets = 3;
 
     [DataField]
-    public int MinTargets = 3;
+    public int MinTargets = 1;
 
     [DataField]
     public int TargetsPerPlayer = 20;

--- a/Content.Server/_Sunrise/BloodCult/Objectives/Components/KillCultistTargetConditionComponent.cs
+++ b/Content.Server/_Sunrise/BloodCult/Objectives/Components/KillCultistTargetConditionComponent.cs
@@ -5,8 +5,6 @@ namespace Content.Server._Sunrise.BloodCult.Objectives.Components;
 [RegisterComponent, Access(typeof(KillCultistTargetsConditionSystem))]
 public sealed partial class KillCultistTargetsConditionComponent : Component
 {
-    public List<EntityUid> Targets = new();
-
     [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
     public string Title = string.Empty;
 }

--- a/Content.Server/_Sunrise/BloodCult/Objectives/Systems/KillCultistTargetConditionSystem.cs
+++ b/Content.Server/_Sunrise/BloodCult/Objectives/Systems/KillCultistTargetConditionSystem.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Content.Server._Sunrise.BloodCult.GameRule;
 using Content.Server._Sunrise.BloodCult.Objectives.Components;
 using Content.Shared.Mind;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Roles.Jobs;
 
@@ -14,8 +13,6 @@ public sealed class KillCultistTargetsConditionSystem : EntitySystem
     [Dependency] private readonly SharedJobSystem _job = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
-    [Dependency] private readonly MobStateSystem _mobState = default!;
-    [Dependency] private readonly EntityManager _entityManager = default!;
 
     public override void Initialize()
     {
@@ -24,39 +21,28 @@ public sealed class KillCultistTargetsConditionSystem : EntitySystem
         SubscribeLocalEvent<KillCultistTargetsConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
 
         SubscribeLocalEvent<KillCultistTargetsConditionComponent, ObjectiveAssignedEvent>(OnPersonAssigned);
-        SubscribeLocalEvent<KillCultistTargetsConditionComponent, ObjectiveAfterAssignEvent>(OnAfterAssign);
     }
 
-    public void SetTargets(EntityUid uid, KillCultistTargetsConditionComponent comp, List<EntityUid> targets)
+    public void RefresTitle(EntityUid uid, Dictionary<EntityUid, bool> targets, KillCultistTargetsConditionComponent comp)
     {
-        comp.Targets = targets;
+        _metaData.SetEntityName(uid, GetTitle(targets, comp.Title));
     }
 
-    public void RefresTitle(EntityUid uid, KillCultistTargetsConditionComponent comp)
-    {
-        _metaData.SetEntityName(uid, GetTitle(comp.Targets, comp.Title));
-    }
-
-    private void OnAfterAssign(EntityUid uid,
-        KillCultistTargetsConditionComponent comp,
-        ref ObjectiveAfterAssignEvent args)
-    {
-        _metaData.SetEntityName(uid, GetTitle(comp.Targets, comp.Title), args.Meta);
-    }
-
-    private string GetTitle(List<EntityUid> targets, string title)
+    private string GetTitle(Dictionary<EntityUid, bool> targets, string title)
     {
         var targetsList = "";
         foreach (var target in targets)
         {
-            if (!TryComp<MindComponent>(target, out var mind) || mind.CharacterName == null)
+            if (!_mind.TryGetMind(target.Key, out var mindId, out var mind) || mind.CharacterName == null)
                 continue;
 
             var targetName = mind.CharacterName;
-            var jobName = _job.MindTryGetJobName(target);
+            var jobName = _job.MindTryGetJobName(mindId);
+            var sacrificed = target.Value ? "\u2714" : "\u2718";
             targetsList += Loc.GetString("objective-condition-cult-kill-target",
                 ("targetName", targetName),
-                ("job", jobName));
+                ("job", jobName),
+                ("status", sacrificed));
             targetsList += "\n";
         }
 
@@ -67,34 +53,22 @@ public sealed class KillCultistTargetsConditionSystem : EntitySystem
         KillCultistTargetsConditionComponent comp,
         ref ObjectiveGetProgressEvent args)
     {
-        args.Progress = KillCultistTargetsProgress(args.MindId);
+        args.Progress = KillCultistTargetsProgress();
     }
 
     private void OnPersonAssigned(EntityUid uid,
         KillCultistTargetsConditionComponent component,
         ref ObjectiveAssignedEvent args)
     {
-        // target already assigned
-        if (component.Targets.Count != 0)
+        var cultistRule = EntityManager.EntityQuery<BloodCultRuleComponent>().FirstOrDefault();
+
+        if (cultistRule == null)
             return;
 
-        var cultistRule = EntityManager.EntityQuery<BloodCultRuleComponent>().FirstOrDefault();
-        Debug.Assert(cultistRule != null, nameof(cultistRule) + " != null");
-        var cultTargets = cultistRule.CultTargets;
-
-        component.Targets = cultTargets;
+        _metaData.SetEntityName(uid, GetTitle(cultistRule.CultTargets, component.Title));
     }
 
-    private bool GetTagretProgress(EntityUid target)
-    {
-        // цель мертва или гибнута, в идеале перенести в sacrifice руны
-        if (_mobState.IsDead(target) || !_entityManager.EntityExists(target))
-            return true;
-
-        return false;
-    }
-
-    private float KillCultistTargetsProgress(EntityUid? mindId)
+    private float KillCultistTargetsProgress()
     {
         var cultistRule = EntityManager.EntityQuery<BloodCultRuleComponent>().FirstOrDefault();
         Debug.Assert(cultistRule != null, nameof(cultistRule) + " != null");
@@ -110,7 +84,7 @@ public sealed class KillCultistTargetsConditionSystem : EntitySystem
 
         foreach (var cultTarget in cultTargets)
         {
-            if (GetTagretProgress(cultTarget))
+            if (cultTarget.Value)
             {
                 deadTargetsCount += 1;
             }

--- a/Content.Server/_Sunrise/BloodCult/Runes/Systems/BloodCultSystem.Rune.cs
+++ b/Content.Server/_Sunrise/BloodCult/Runes/Systems/BloodCultSystem.Rune.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Numerics;
 using Content.Server._Sunrise.BloodCult.GameRule;
+using Content.Server._Sunrise.BloodCult.Objectives.Components;
 using Content.Server._Sunrise.BloodCult.Runes.Comps;
 using Content.Server.Atmos.Components;
 using Content.Server.Bible.Components;
@@ -93,7 +94,9 @@ namespace Content.Server._Sunrise.BloodCult.Runes.Systems
 
         private void TeleportRuneInit(EntityUid uid, CultRuneTeleportComponent component, MapInitEvent args)
         {
-            component.Label = Loc.GetString("cult-teleport-rune-default-label");
+            var xform = Transform(uid);
+            var location = FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform), true));
+            component.Label = location;
         }
 
         /*
@@ -422,15 +425,22 @@ namespace Content.Server._Sunrise.BloodCult.Runes.Systems
 
             var cultTargets = rule.CultTargets;
 
+            var isTarget = cultTargets.ContainsKey(victim.Value);
+
+            if (isTarget)
+            {
+                result = Sacrifice(uid, victim.Value, args.User, args.Cultists, rule, isTarget);
+                args.Result = result;
+                return;
+            }
+
             if (state.CurrentState != MobState.Dead)
             {
                 var hasMind = _mindSystem.TryGetMind(victim.Value, out var mindId, out var mind);
 
-                var isTarget = cultTargets.Contains(victim.Value);
-
                 var jobAllowConvert = !HasComp<MindShieldComponent>(victim.Value);
 
-                if (hasMind && jobAllowConvert && !isTarget)
+                if (hasMind && jobAllowConvert)
                 {
                     if (args.Cultists.Count < component.ConvertMinCount)
                     {
@@ -474,6 +484,14 @@ namespace Content.Server._Sunrise.BloodCult.Runes.Systems
 
             if (isTarget)
             {
+                rule.CultTargets[target] = true;
+                var query = EntityQueryEnumerator<KillCultistTargetsConditionComponent>();
+
+                while (query.MoveNext(out var obj, out var killCultistTargetsComponent))
+                {
+                    _cultistTargetsConditionSystem.RefresTitle(obj, rule.CultTargets, killCultistTargetsComponent);
+                }
+
                 _bodySystem.GibBody(target);
                 _bloodCultRuleSystem.ChangeSacrificeCount(rule, rule.SacrificeCount + 1);
 

--- a/Content.Server/_Sunrise/BloodCult/Runes/Systems/BloodCultSystem.cs
+++ b/Content.Server/_Sunrise/BloodCult/Runes/Systems/BloodCultSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server._Sunrise.BloodCult.GameRule;
+using Content.Server._Sunrise.BloodCult.Objectives.Systems;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
 using Content.Server.Chat.Systems;
@@ -83,6 +84,7 @@ namespace Content.Server._Sunrise.BloodCult.Runes.Systems
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly NavMapSystem _navMap = default!;
         [Dependency] private readonly PullingSystem _pulling = default!;
+        [Dependency] private readonly KillCultistTargetsConditionSystem _cultistTargetsConditionSystem = default!;
 
         [ValidatePrototypeId<StackPrototype>]
         private static string SteelStackPrototypeId = "Steel";

--- a/Resources/Locale/ru-RU/_strings/_sunrise/blood-cult/cult.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/blood-cult/cult.ftl
@@ -47,7 +47,7 @@ chat-manager-cult-channel-name = Культ
 chat-manager-send-cult-chat-wrap-message = [bold]\[{ $channelName }\] { $player }: { $message }[/bold]
 hud-chatbox-select-channel-Cult = Культ
 # Objectivies
-objective-condition-cult-kill-target = { $targetName } [{ CAPITALIZE($job) }].
+objective-condition-cult-kill-target = { $targetName } ({ CAPITALIZE($job) }) - { $status }
 objective-condition-cult-kill-title =
     Жертвы:
-    { $targets }.
+    { $targets }


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Решает https://github.com/space-sunrise/sunrise-station/issues/1629

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->

:cl: VigersRay
- fix: Исправлено отображение целей культа крови.
- tweak: Теперь для того чтобы цель культа на жертвоприношение считалась успешной её необходимо принести в жертву на руне поднесения (Ранее достаточно было убить или гибнуть).
- tweak: Если цель на жертвоприношение культа уйдет в крио - она будет убрана из задачи культа и культ получит новую цель. 
- tweak: Если цель культа на жертвоприношение будет удалена или гибнута - аналогично произойдет перевыбор цели.
- tweak: Теперь в задаче культа можно видеть какие цели уже были принесены в жертву, а какие нет. Галочка - да, крестик - нет.
- fix: Исправлена ошибка которая всегда выдавала культу 3 цели а не 1-3 в зависимости от онлайна.
- tweak: Теперь созданая руна телепортации культа крови будет иметь название в зависимости от её местоположения.