### PR TITLE
Защита у дракона

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -55,6 +55,8 @@
     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
       state: alive-unshaded
       shader: unshaded
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: Appearance
   - type: DamageStateVisuals
     states:

--- a/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
@@ -41,10 +41,11 @@
 - type: damageModifierSet
   id: Dragon
   coefficients:
-    Blunt: 0.8
-    Slash: 0.8
-    Piercing: 0.8
-    Heat: 0.6
+    Blunt: 0.55
+    Slash: 0.55
+    Piercing: 0.4
+    Heat: 0.4
+    Shock: 0.5
 
 - type: damageModifierSet
   id: Rift


### PR DESCRIPTION

## Кратное описание
Изменил дракону резисты и защиту от взрывов

## По какой причине
Резисты - Урон пулям вернули, дракона не баффнули. Как итог он убивается с 1-1,5 магазина любой ППшки. От электричества потому что на обшивке порой стоят решетки под ВВ и сносят дракону половину ХП
Защита от взрыва - У дракона есть фаербол, который его самого может убить, опять же - хрень

**Changelog**

:cl: justjhel
- add: Добавлена защита от взрывов и электрического урона дракону 
- tweak: Изменена защита от механического и физического урона дракону.