### PR TITLE
Уменьшение урона у клинка культа плоти

### DIFF
--- a/Resources/Prototypes/_Sunrise/FleshCult/hands_mods.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/hands_mods.yml
@@ -97,7 +97,7 @@
     - type: MeleeWeapon
       damage:
         types:
-          Slash: 40
+          Slash: 30
     - type: Item
       size: Huge
       sprite: _Sunrise/FleshCult/FleshHandMods/flesh_blade.rsi


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Понижение урона у клинка культа плоти

## По какой причине
40 урона - слишком много, никакая броня от этого не спасёт. Сверху накладывается ещё бесконечный мет для ускорения и внушительное лечене.

**Changelog**

:cl: Kendrick
- tweak: Урон клинка культа плоти понижен
