### PR TITLE
Цены на газ

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 2.5
+  pricePerMole: 1.5
 
 - type: gas
   id: 5
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 0.1
+  pricePerMole: 1
 
 - type: gas
   id: 8
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 1
+  pricePerMole: 3

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 1.5
+  pricePerMole: 1.5 #Sunrise-edit
 
 - type: gas
   id: 5
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 1
+  pricePerMole: 1 #Sunrise-edit
 
 - type: gas
   id: 8
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 3
+  pricePerMole: 3 #Sunrise-edit

--- a/Resources/Prototypes/_Sunrise/Atmospherics/gases.yml
+++ b/Resources/Prototypes/_Sunrise/Atmospherics/gases.yml
@@ -18,7 +18,7 @@
   molarMass: 10
   color: 8b0000
   reagent: Healium
-  pricePerMole: 3
+  pricePerMole: 12
   gasOverlaySprite: /Textures/_Sunrise/Effects/atmospherics.rsi
   gasOverlayState: healium
 
@@ -30,7 +30,7 @@
   molarMass: 30
   color: 8B4513
   reagent: Nitrium
-  pricePerMole: 0.2
+  pricePerMole: 2
   gasOverlaySprite: /Textures/_Sunrise/Effects/atmospherics.rsi
   gasOverlayState: nitriumGas
 


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Поскольку ботаникам порезали газ, считаю справедливым вернуть +- старые цены. 
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Как я написал выше, ботаники, вроде, больше не могут устраивать фермы на хилиуме а атмосы, последние месяца два, варят максимум тритий на упаковщике, думаю им стоит внести немного мотивации для варки других газов. 

Собсна почему так? Если коротко, то:
Тритий порезал до 1.5, ибо средненький атмос на Ласте может за 13-15 минут наварить 45к моль трития, дав карго нехилый буст. 
Цену Фрезона поднял, это более сложный в синтезе газ чем Тритий, но сейчас его варить не выгодно, по этому с этой ценой атмосы должны будут пересесть именно на него. 
Цену Хилиума поднял (на самом деле его действительно долго и сложно синтезировать, даже с ускорением), ибо фармёжка ботаников кончилась. Нитриум по той же причине. 
Оксид особо никто не продаёт, но это так называемая "сдача" у атмосов. Старые приколы.

Так и так это даст атмосом немного больше желания пробовать варить что то кроме двух газов.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: TERRISS
- tweak: Цены на газы были изменены.