### PR TITLE
Удаление гипоручек с аплинка ЯО

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -670,7 +670,12 @@
   cost:
     Telecrystal: 6
   categories:
-  - UplinkChemicals
+  - UplinkChemicals #sunrise-start
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - SubdermalImplant
+      - NukeOpsUplink #sunrise-end
 
 - type: listing
   id: UplinkHypoDart


### PR DESCRIPTION
## Кратное описание
Удалить гипоручку из аплинка ЯО

## По какой причине
Гипоручки нужны для агентов, воров и ДО, чтобы усыплять свои цели и скрытно их выполнять. ЯО же используют гипоручки как полноценные гипоспреи, чтобы лечить себя во время боя и вводить себе мет во время боя, сам же гипоспрей есть только у медика.

**Changelog**
:cl: Kendrick
- remove: У ядерных оперативников больше нет гипоручек.
