### PR TITLE
уменьшение количества крови у крысиных слуг

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -193,6 +193,9 @@
         2.0
       FollowRange: !type:Single
         3.0
+  - type: Bloodstream
+    bloodReagent: Blood
+    bloodMaxVolume: 75
   - type: Reactive
     groups:
       Flammable: [Touch]


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Количество крови у крысиных слуг было уменьшено с 150 до 75.

## По какой причине
ишуй #1935

## Медиа(Видео/Скриншоты)

**Changelog**

:cl: agranomys
- tweak: Изменено количество крови у крысиных слуг.
