### PR TITLE
Возвращение Ультры в фабрикатор

### DIFF
--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/robotics.yml
@@ -49,6 +49,7 @@
   - MechPhasicScanningModule
   - WeaponMechCombatSolarisLaser
   - WeaponMechCombatFiredartLaser
+  - WeaponMechCombatUltraRifle
   - PaintRipleyAluminizer
   - PaintRipleyFirestarter
   - PaintRipleyHauler


### PR DESCRIPTION
## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Ультра возвращена в фабрикатор экзокостюмов

## По какой причине

https://github.com/space-sunrise/sunrise-station/issues/1921

## Медиа(Видео/Скриншоты)

**Changelog**

:cl: Cokolr

- tweak: Ультра возвращена в фабрикатор экзокостюмов.

