### PR TITLE
Двойные одеяла на багеле

### DIFF
--- a/Resources/Maps/_Sunrise/Station/bagel.yml
+++ b/Resources/Maps/_Sunrise/Station/bagel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 254.1.0
   forkId: ""
   forkVersion: ""
-  time: 04/20/2025 06:46:09
-  entityCount: 27291
+  time: 04/22/2025 23:22:07
+  entityCount: 27286
 maps:
 - 1
 grids:
@@ -11656,7 +11656,7 @@ entities:
       pos: -21.5,-20.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -64628.38
+      secondsUntilStateChange: -65193.2
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11675,7 +11675,7 @@ entities:
       pos: -21.5,-18.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -64628.914
+      secondsUntilStateChange: -65193.734
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13252,7 +13252,7 @@ entities:
       pos: 36.5,30.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -38903.62
+      secondsUntilStateChange: -39468.44
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13655,7 +13655,7 @@ entities:
       pos: 44.5,27.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -57041.344
+      secondsUntilStateChange: -57606.164
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -16351,234 +16351,27 @@ entities:
     - type: Transform
       pos: 27.420593,-33.39672
       parent: 2
-- proto: DoubleBed
+- proto: Bed
   entities:
-  - uid: 848
-    components:
-    - type: Transform
-      pos: 7.5,-32.5
-      parent: 2
-  - uid: 849
-    components:
-    - type: Transform
-      pos: 39.5,-14.5
-      parent: 2
-  - uid: 850
-    components:
-    - type: Transform
-      pos: 52.5,-44.5
-      parent: 2
-  - uid: 851
-    components:
-    - type: Transform
-      pos: -6.5,24.5
-      parent: 2
-  - uid: 852
-    components:
-    - type: Transform
-      pos: -18.5,-10.5
-      parent: 2
-  - uid: 853
-    components:
-    - type: Transform
-      pos: -18.5,-13.5
-      parent: 2
-  - uid: 854
-    components:
-    - type: Transform
-      pos: -33.5,-10.5
-      parent: 2
-  - uid: 855
-    components:
-    - type: Transform
-      pos: -33.5,-7.5
-      parent: 2
-  - uid: 856
-    components:
-    - type: Transform
-      pos: -33.5,-13.5
-      parent: 2
-  - uid: 857
-    components:
-    - type: Transform
-      pos: -19.5,0.5
-      parent: 2
-  - uid: 858
-    components:
-    - type: Transform
-      pos: 30.5,-14.5
-      parent: 2
-  - uid: 859
-    components:
-    - type: Transform
-      pos: 45.5,16.5
-      parent: 2
-  - uid: 860
-    components:
-    - type: Transform
-      pos: 48.5,-34.5
-      parent: 2
-  - uid: 861
-    components:
-    - type: Transform
-      pos: -63.5,3.5
-      parent: 2
-  - uid: 862
-    components:
-    - type: Transform
-      pos: 12.5,17.5
-      parent: 2
-  - uid: 863
-    components:
-    - type: Transform
-      pos: -40.5,7.5
-      parent: 2
-  - uid: 864
-    components:
-    - type: Transform
-      pos: 49.5,-27.5
-      parent: 2
-  - uid: 865
-    components:
-    - type: Transform
-      pos: 49.5,-29.5
-      parent: 2
-  - uid: 866
-    components:
-    - type: Transform
-      pos: 47.5,-29.5
-      parent: 2
-  - uid: 867
-    components:
-    - type: Transform
-      pos: 52.5,-45.5
-      parent: 2
-  - uid: 868
-    components:
-    - type: Transform
-      pos: 56.5,-45.5
-      parent: 2
-  - uid: 869
-    components:
-    - type: Transform
-      pos: -35.5,-36.5
-      parent: 2
   - uid: 870
-    components:
-    - type: Transform
-      pos: -7.5,-13.5
-      parent: 2
-  - uid: 871
     components:
     - type: Transform
       pos: -7.5,-12.5
       parent: 2
-  - uid: 872
+  - uid: 871
     components:
     - type: Transform
-      pos: 47.5,16.5
-      parent: 2
-  - uid: 873
-    components:
-    - type: Transform
-      pos: -19.5,18.5
-      parent: 2
-  - uid: 874
-    components:
-    - type: Transform
-      pos: -45.5,19.5
-      parent: 2
-  - uid: 875
-    components:
-    - type: Transform
-      pos: -45.5,21.5
-      parent: 2
-  - uid: 876
-    components:
-    - type: Transform
-      pos: -55.5,25.5
-      parent: 2
-  - uid: 877
-    components:
-    - type: Transform
-      pos: -55.5,23.5
-      parent: 2
-  - uid: 878
-    components:
-    - type: Transform
-      pos: -55.5,21.5
-      parent: 2
-  - uid: 879
-    components:
-    - type: Transform
-      pos: -45.5,25.5
+      pos: -7.5,-13.5
       parent: 2
   - uid: 880
     components:
     - type: Transform
-      pos: -45.5,23.5
-      parent: 2
-  - uid: 881
-    components:
-    - type: Transform
-      pos: -34.5,20.5
-      parent: 2
-  - uid: 882
-    components:
-    - type: Transform
-      pos: 6.5,-14.5
-      parent: 2
-  - uid: 883
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
+      pos: 43.5,33.5
       parent: 2
   - uid: 884
     components:
     - type: Transform
-      pos: 49.5,-23.5
-      parent: 2
-  - uid: 885
-    components:
-    - type: Transform
-      pos: 43.5,33.5
-      parent: 2
-  - uid: 886
-    components:
-    - type: Transform
       pos: 43.5,32.5
-      parent: 2
-  - uid: 887
-    components:
-    - type: Transform
-      pos: 12.5,36.5
-      parent: 2
-  - uid: 888
-    components:
-    - type: Transform
-      pos: 66.5,-1.5
-      parent: 2
-  - uid: 889
-    components:
-    - type: Transform
-      pos: 9.5,-36.5
-      parent: 2
-  - uid: 890
-    components:
-    - type: Transform
-      pos: -7.5,4.5
-      parent: 2
-  - uid: 26969
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 26952
-- proto: BedsheetBlack
-  entities:
-  - uid: 891
-    components:
-    - type: Transform
-      pos: 9.5,-36.5
       parent: 2
 - proto: BedsheetBrigmedic
   entities:
@@ -16586,27 +16379,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,4.5
-      parent: 2
-- proto: BedsheetBrown
-  entities:
-  - uid: 893
-    components:
-    - type: Transform
-      pos: 66.5,-1.5
-      parent: 2
-- proto: BedsheetCaptain
-  entities:
-  - uid: 894
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
-      parent: 2
-- proto: BedsheetCE
-  entities:
-  - uid: 895
-    components:
-    - type: Transform
-      pos: 12.5,17.5
       parent: 2
 - proto: BedsheetClown
   entities:
@@ -16621,18 +16393,6 @@ entities:
     components:
     - type: Transform
       pos: 34.5,-10.5
-      parent: 2
-  - uid: 898
-    components:
-    - type: Transform
-      pos: 30.5,-14.5
-      parent: 2
-- proto: BedsheetCult
-  entities:
-  - uid: 899
-    components:
-    - type: Transform
-      pos: -19.5,18.5
       parent: 2
 - proto: BedsheetGreen
   entities:
@@ -16650,20 +16410,6 @@ entities:
     components:
     - type: Transform
       pos: 49.5,-27.5
-      parent: 2
-- proto: BedsheetHOP
-  entities:
-  - uid: 903
-    components:
-    - type: Transform
-      pos: 7.5,-32.5
-      parent: 2
-- proto: BedsheetHOS
-  entities:
-  - uid: 904
-    components:
-    - type: Transform
-      pos: -19.5,0.5
       parent: 2
 - proto: BedsheetIan
   entities:
@@ -16711,6 +16457,16 @@ entities:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
+  - uid: 928
+    components:
+    - type: Transform
+      pos: 39.5,-14.5
+      parent: 2
+  - uid: 933
+    components:
+    - type: Transform
+      pos: 49.5,-23.5
+      parent: 2
 - proto: BedsheetMime
   entities:
   - uid: 915
@@ -16750,94 +16506,12 @@ entities:
     - type: Transform
       pos: -7.5,-12.5
       parent: 2
-- proto: BedsheetQM
-  entities:
-  - uid: 922
-    components:
-    - type: Transform
-      pos: 45.5,16.5
-      parent: 2
-- proto: BedsheetRD
-  entities:
-  - uid: 923
-    components:
-    - type: Transform
-      pos: -40.5,7.5
-      parent: 2
-- proto: BedsheetRed
-  entities:
-  - uid: 924
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,36.5
-      parent: 2
 - proto: BedsheetSpawner
   entities:
-  - uid: 925
-    components:
-    - type: Transform
-      pos: 52.5,-44.5
-      parent: 2
-  - uid: 926
-    components:
-    - type: Transform
-      pos: -6.5,24.5
-      parent: 2
   - uid: 927
     components:
     - type: Transform
       pos: 48.5,-34.5
-      parent: 2
-  - uid: 928
-    components:
-    - type: Transform
-      pos: 52.5,-45.5
-      parent: 2
-  - uid: 929
-    components:
-    - type: Transform
-      pos: 56.5,-45.5
-      parent: 2
-  - uid: 930
-    components:
-    - type: Transform
-      pos: -45.5,19.5
-      parent: 2
-  - uid: 931
-    components:
-    - type: Transform
-      pos: -45.5,21.5
-      parent: 2
-  - uid: 932
-    components:
-    - type: Transform
-      pos: -55.5,25.5
-      parent: 2
-  - uid: 933
-    components:
-    - type: Transform
-      pos: -55.5,23.5
-      parent: 2
-  - uid: 934
-    components:
-    - type: Transform
-      pos: -55.5,21.5
-      parent: 2
-  - uid: 935
-    components:
-    - type: Transform
-      pos: -45.5,23.5
-      parent: 2
-  - uid: 936
-    components:
-    - type: Transform
-      pos: -45.5,25.5
-      parent: 2
-  - uid: 937
-    components:
-    - type: Transform
-      pos: -34.5,20.5
       parent: 2
 - proto: BedsheetSyndie
   entities:
@@ -16857,20 +16531,6 @@ entities:
     - type: Transform
       pos: 3.5,-3.5
       parent: 26952
-- proto: BedsheetUSA
-  entities:
-  - uid: 940
-    components:
-    - type: Transform
-      pos: -63.5,3.5
-      parent: 2
-- proto: BedsheetWiz
-  entities:
-  - uid: 941
-    components:
-    - type: Transform
-      pos: -35.5,-36.5
-      parent: 2
 - proto: BikeHorn
   entities:
   - uid: 942
@@ -74651,6 +74311,311 @@ entities:
     - type: Transform
       pos: 9.502107,15.46938
       parent: 2
+- proto: DoubleBed
+  entities:
+  - uid: 848
+    components:
+    - type: Transform
+      pos: 7.5,-32.5
+      parent: 2
+  - uid: 850
+    components:
+    - type: Transform
+      pos: 52.5,-44.5
+      parent: 2
+  - uid: 851
+    components:
+    - type: Transform
+      pos: -6.5,24.5
+      parent: 2
+  - uid: 852
+    components:
+    - type: Transform
+      pos: -18.5,-10.5
+      parent: 2
+  - uid: 853
+    components:
+    - type: Transform
+      pos: -18.5,-13.5
+      parent: 2
+  - uid: 854
+    components:
+    - type: Transform
+      pos: -33.5,-10.5
+      parent: 2
+  - uid: 855
+    components:
+    - type: Transform
+      pos: -33.5,-7.5
+      parent: 2
+  - uid: 856
+    components:
+    - type: Transform
+      pos: -33.5,-13.5
+      parent: 2
+  - uid: 857
+    components:
+    - type: Transform
+      pos: -19.5,0.5
+      parent: 2
+  - uid: 858
+    components:
+    - type: Transform
+      pos: 30.5,-14.5
+      parent: 2
+  - uid: 859
+    components:
+    - type: Transform
+      pos: 45.5,16.5
+      parent: 2
+  - uid: 860
+    components:
+    - type: Transform
+      pos: 48.5,-34.5
+      parent: 2
+  - uid: 861
+    components:
+    - type: Transform
+      pos: -63.5,3.5
+      parent: 2
+  - uid: 862
+    components:
+    - type: Transform
+      pos: 12.5,17.5
+      parent: 2
+  - uid: 863
+    components:
+    - type: Transform
+      pos: -40.5,7.5
+      parent: 2
+  - uid: 868
+    components:
+    - type: Transform
+      pos: 56.5,-45.5
+      parent: 2
+  - uid: 869
+    components:
+    - type: Transform
+      pos: -35.5,-36.5
+      parent: 2
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 47.5,16.5
+      parent: 2
+  - uid: 873
+    components:
+    - type: Transform
+      pos: -19.5,18.5
+      parent: 2
+  - uid: 874
+    components:
+    - type: Transform
+      pos: -45.5,19.5
+      parent: 2
+  - uid: 876
+    components:
+    - type: Transform
+      pos: -55.5,25.5
+      parent: 2
+  - uid: 878
+    components:
+    - type: Transform
+      pos: -55.5,21.5
+      parent: 2
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -45.5,25.5
+      parent: 2
+  - uid: 881
+    components:
+    - type: Transform
+      pos: -34.5,20.5
+      parent: 2
+  - uid: 882
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 2
+  - uid: 883
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 887
+    components:
+    - type: Transform
+      pos: 12.5,36.5
+      parent: 2
+  - uid: 888
+    components:
+    - type: Transform
+      pos: 66.5,-1.5
+      parent: 2
+  - uid: 889
+    components:
+    - type: Transform
+      pos: 9.5,-36.5
+      parent: 2
+  - uid: 890
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 26969
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 26952
+- proto: DoubleBedsheetBlack
+  entities:
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 56.5,-45.5
+      parent: 2
+  - uid: 885
+    components:
+    - type: Transform
+      pos: 9.5,-36.5
+      parent: 2
+- proto: DoubleBedsheetBlue
+  entities:
+  - uid: 926
+    components:
+    - type: Transform
+      pos: -55.5,21.5
+      parent: 2
+  - uid: 930
+    components:
+    - type: Transform
+      pos: -34.5,20.5
+      parent: 2
+- proto: DoubleBedsheetBrown
+  entities:
+  - uid: 886
+    components:
+    - type: Transform
+      pos: 66.5,-1.5
+      parent: 2
+  - uid: 924
+    components:
+    - type: Transform
+      pos: -6.5,24.5
+      parent: 2
+- proto: DoubleBedsheetCaptain
+  entities:
+  - uid: 891
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+- proto: DoubleBedsheetCE
+  entities:
+  - uid: 893
+    components:
+    - type: Transform
+      pos: 12.5,17.5
+      parent: 2
+- proto: DoubleBedsheetCMO
+  entities:
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 30.5,-14.5
+      parent: 2
+- proto: DoubleBedsheetCult
+  entities:
+  - uid: 895
+    components:
+    - type: Transform
+      pos: -19.5,18.5
+      parent: 2
+- proto: DoubleBedsheetGreen
+  entities:
+  - uid: 929
+    components:
+    - type: Transform
+      pos: -45.5,25.5
+      parent: 2
+- proto: DoubleBedsheetGrey
+  entities:
+  - uid: 875
+    components:
+    - type: Transform
+      pos: -55.5,25.5
+      parent: 2
+- proto: DoubleBedsheetHOP
+  entities:
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 7.5,-32.5
+      parent: 2
+- proto: DoubleBedsheetHOS
+  entities:
+  - uid: 899
+    components:
+    - type: Transform
+      pos: -19.5,0.5
+      parent: 2
+- proto: DoubleBedsheetNT
+  entities:
+  - uid: 923
+    components:
+    - type: Transform
+      pos: 52.5,-44.5
+      parent: 2
+- proto: DoubleBedsheetOrange
+  entities:
+  - uid: 934
+    components:
+    - type: Transform
+      pos: 47.5,16.5
+      parent: 2
+- proto: DoubleBedsheetQM
+  entities:
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 45.5,16.5
+      parent: 2
+- proto: DoubleBedsheetRD
+  entities:
+  - uid: 904
+    components:
+    - type: Transform
+      pos: -40.5,7.5
+      parent: 2
+- proto: DoubleBedsheetRed
+  entities:
+  - uid: 922
+    components:
+    - type: Transform
+      pos: 12.5,36.5
+      parent: 2
+- proto: DoubleBedsheetUSA
+  entities:
+  - uid: 931
+    components:
+    - type: Transform
+      pos: -63.5,3.5
+      parent: 2
+- proto: DoubleBedsheetWiz
+  entities:
+  - uid: 932
+    components:
+    - type: Transform
+      pos: -35.5,-36.5
+      parent: 2
+- proto: DoubleBedsheetYellow
+  entities:
+  - uid: 925
+    components:
+    - type: Transform
+      pos: -45.5,19.5
+      parent: 2
 - proto: DoubleEmergencyOxygenTankFilled
   entities:
   - uid: 8
@@ -77558,7 +77523,7 @@ entities:
       pos: 16.5,-8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -60198.117
+      secondsUntilStateChange: -60762.938
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -119366,6 +119331,31 @@ entities:
       parent: 2
 - proto: MedicalBed
   entities:
+  - uid: 849
+    components:
+    - type: Transform
+      pos: 39.5,-14.5
+      parent: 2
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 49.5,-29.5
+      parent: 2
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 47.5,-29.5
+      parent: 2
+  - uid: 866
+    components:
+    - type: Transform
+      pos: 49.5,-27.5
+      parent: 2
+  - uid: 877
+    components:
+    - type: Transform
+      pos: 49.5,-23.5
+      parent: 2
   - uid: 18039
     components:
     - type: Transform
@@ -167557,7 +167547,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -52914.273
+      secondsUntilStateChange: -53479.094
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Замена обычных одеял на двойные

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: agranomys
- tweak: Добавлены двойные одеяла на станции Bagel

