### PR TITLE
Самооборона ревенанта

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -88,3 +88,11 @@
   - type: TTS
     voice: HermaeusMora
   # Sunrise-end
+  # Sunrise-start
+  - type: Electrified
+    onHandInteract: false
+    onInteractUsing: false
+    onBump: false
+    requirePower: false
+    shockDamage: 30
+  # Sunrise-end


### PR DESCRIPTION
## Кратное описание

Добавил ревенанту свойство электрической решетки. При попытке его ударить без изолированных перчаток, обидчика ударит током на 30 урона.

## По какой причине

Врачи, что при первой же возможности забивают ревенанта, мне не нравятся, пусть бьются током / носят изоли.

**Changelog**

:cl: justjhel
- add: Добавлен урон при попытке ударить ревенанта в ближнем бою без изол. перчаток
