### PR TITLE
Фикс цены сантиков

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/suntick.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/suntick.yml
@@ -18,7 +18,7 @@
   - type: StaticPrice
     price: 0
   - type: StackPrice
-    price: 10
+    price: -10
   - type: Currency
     price:
       Suntick: 1

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/suntick.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/suntick.yml
@@ -18,7 +18,7 @@
   - type: StaticPrice
     price: 0
   - type: StackPrice
-    price: -2000
+    price: 10
   - type: Currency
     price:
       Suntick: 1


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Поставил цену сантикам 10 кредитов

## По какой причине
С отрицательной стоимостью сантики позволяют набегаторам выводить баланс карго в отрицательные числа

**Changelog**

:cl: Kendrick
- tweak: Штраф за продажу сантиков теперь составляет 10 кредитов вместо 2000.
