### PR TITLE
Ослабление дракона

### DIFF
--- a/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
@@ -41,10 +41,10 @@
 - type: damageModifierSet
   id: Dragon
   coefficients:
-    Blunt: 0.55
-    Slash: 0.55
-    Piercing: 0.4
-    Heat: 0.4
+    Blunt: 0.7
+    Slash: 0.7
+    Piercing: 0.7
+    Heat: 0.6
     Shock: 0.5
 
 - type: damageModifierSet


### PR DESCRIPTION

## Кратное описание
Ослабил резисты дракону 
## По какой причине
Слова о том, что дракон стал имбой и бла бла бла. 
До прежних не вернул потому, что урон пулям все же подняли, а разлом дефать как то надо. 

**Changelog**

:cl: justjhel
- tweak: Дракону понижены резисты от механических и ожогов.
