### PR TITLE
Ребаланс Яутжа/Троттинов

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -26,6 +26,10 @@
         conditions:
         - !type:OrganType
           type: Plant
+      - !type:Oxygenate #Sunrise-Start
+        conditions:
+        - !type:OrganType
+          type: Predator #Sunrise-End
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
@@ -70,6 +74,10 @@
           type: Rat
       - !type:Oxygenate
         conditions:
+        - !type:OrganType
+          type: Predator #Sunrise-Start
+      - !type:Oxygenate
+        conditions: #Sunrise-End
         - !type:OrganType
           type: Plant
       # Convert Oxygen into CO2.
@@ -297,6 +305,25 @@
         ratios:
           NitrousOxide: 1.0
           Nitrogen: -1.0
+      - !type:HealthChange #Sunrise-Start
+        conditions:
+        - !type:OrganType
+          type: Predator
+        scaleByQuantity: true
+        ignoreResistances: true
+        damage:
+          types:
+            Poison:
+              0.5
+      - !type:AdjustAlert
+        alertType: Toxins
+        conditions:
+          - !type:ReagentThreshold
+            min: 0.5
+          - !type:OrganType
+            type: Predator
+        clear: true
+        time: 5 #Sunrise-End
 
 - type: reagent
   id: NitrousOxide

--- a/Resources/Prototypes/_Sunrise/Body/Organs/predator.yml
+++ b/Resources/Prototypes/_Sunrise/Body/Organs/predator.yml
@@ -114,7 +114,7 @@
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Human ]
+    metabolizerTypes: [ Predator ]
     groups:
     - id: Gas
       rateModifier: 100.0

--- a/Resources/Prototypes/_Sunrise/Body/Organs/swine.yml
+++ b/Resources/Prototypes/_Sunrise/Body/Organs/swine.yml
@@ -1,10 +1,10 @@
 - type: entity
   id: OrganSwineStomach
-  parent: OrganAnimalStomach
+  parent: OrganManeaterAnimalStomach
   categories: [ HideSpawnMenu ]
   components:
+    - type: Stomach
     - type: SolutionContainerManager
       solutions:
         stomach:
           maxVol: 200
-    - type: Stomach

--- a/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
@@ -10,21 +10,21 @@
 - type: damageModifierSet
   id: Swine
   coefficients:
-    Blunt: 0.5
-    Slash: 0.7
-    Piercing: 0.7
-    Cold: 0.5
-    Heat: 0.5
+    Blunt: 0.85
+    Slash: 0.9
+    Piercing: 0.85
+    Cold: 0.8
+    Heat: 0.8
 
 - type: damageModifierSet
   id: Predator
   coefficients:
-    Blunt: 0.9
-    Slash: 0.9
-    Piercing: 0.9
-    Heat: 0.9
-    Shock: 0.9
-    Cold: 0.9
+    Blunt: 0.5
+    Slash: 0.7
+    Piercing: 0.7
+    Heat: 0.5
+    Shock: 0.8
+    Cold: 0.5
     Poison: 0.8
 
 - type: damageModifierSet

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/predator.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/predator.yml
@@ -13,7 +13,7 @@
   - type: Thirst
     dehydrationDamage:
       types:
-        Bloodloss: 0.5
+        Bloodloss: 0.5 #
         Asphyxiation: 0.5
   - type: Perishable
   - type: HumanoidAppearance
@@ -48,6 +48,18 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
+  - type: PassiveDamage
+    # Augment normal health regen to be able to tank some Poison damage
+    # This allows Predators to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
+    allowedStates:
+    - Alive
+    damageCap: 20
+    damage:
+      types:
+        Heat: -0.07
+        Poison: -0.2
+      groups:
+        Brute: -0.07
   - type: Bloodstream
     bloodReagent: FluorosulfuricAcidPredator
   - type: DamageVisuals

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/swine.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/swine.yml
@@ -8,7 +8,7 @@
   - type: HumanoidAppearance
     species: Swine
   - type: Hunger
-    baseDecayRate: 0.04
+    baseDecayRate: 0.25
   - type: Thirst
     baseDecayRate: 0.15
     dehydrationDamage:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
- Резисты троттинов были понижены. Они всё ещё защищены от урона, однако меньше, чем раньше.
- Резисты яутжа были позаимствованы со старых резистов троттинов, они теперь весьма хорошо защищены даже без брони, однако, они платят за это тем, что азот теперь для них смертоносный токсин, они должны дышать чистым кислородом, чтобы не задыхаться.

## По какой причине
Баланс рас

**Changelog**

:cl: Kendrick
- tweak: Изменены резисты троттинов и яутжа: Троттины значительно хуже защищены, а яутжа - крепче
- tweak: Яутжа теперь вынуждены всегда дышать кислородом, азот для них смертоносный яд.
- tweak: Жрать вечно: Троттины быстрее голодают и больше пищи впитывают в свои желудки.
