### PR TITLE
Удаление из антагов из культа плоти и ДО

### DIFF
--- a/Resources/Prototypes/_Sunrise/AssaultOps/game_presets.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/game_presets.yml
@@ -9,7 +9,6 @@
   hide: true
   rules:
     - AssaultOps
-    - SubGamemodesRule
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/_Sunrise/FleshCult/game_preset.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/game_preset.yml
@@ -9,7 +9,6 @@
   hide: true
   rules:
   - FleshCult
-  - SubGamemodesRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
## Кратное описание
Удалил антагов из культа плоти и ДО. Вампиры там всякие, воры и тд

## По какой причине
В раунде и так есть мажор антаг, а если СБ будут еще и всякие вампиры с инвизом убивать то вообще весело (Тоже самое в обратную сторону, вампиру ничего не мешает начать в инвизе убивать культ/ДО). Да и в культе крови этих антагов нет тоже, чем плоть хуже?

**Changelog**

:cl: justjhel
- remove: Удалены вампиры, воры и генокрады из режимов Культа плоти и Диверсионного отряда.

