### PR TITLE
Станрезисты магу

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -759,6 +759,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
+  - type: StaminaResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION

## Кратное описание
50% станрезист на скафандр мага

## По какой причине
Чем скафандр мага хуже ядерных оперативников? Вот и пусть будет станрезист. 

**Changelog**

:cl: justjhe
- add: Добавлен 50% станрезист на скафандр мага
