### PR TITLE
В батарейном оружии теперь сразу высокоёмкая батарейка

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -20,13 +20,13 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: PowerCellSmall
+        startingItem: PowerCellHigh
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
         whitelist:
           tags:
             - PowerCell
-            - PowerCellSmall
+            - PowerCellHigh
 
 - type: entity
   name: LNT620 "Spark"


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Поменял батарейку в батарейном оружии

## По какой причине
Батарейное оружие становится доступным для создания только после изучения высокоёмких батарей. И как минимум такие батареи и нужны на это оружие - иначе оно бесполезно, к тому же в арсенале СБ лежат лазеры, в которых низкие батарейки, теперь будут высокоёмкие, лазер будет эффективнее.

**Changelog**.
:cl: Kendrick
- tweak: В батарейном оружии теперь сразу батареи высокой ёмкости.
