### PR TITLE
[FIX] Одежда корректно отображается на ногах унатхов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -74,7 +74,7 @@
       285: 0.4
   - type: Wagging
   - type: Inventory
-    speciesId: reptilian
+    speciesId: Human
     femaleDisplacements:
       jumpsuit:
         sizeMaps:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Изменил одну строку в прототипе, чтобы ноги унатхов нормально смотрелись, а не криво.

## По какой причине
Исправление визуального недочёта

**Changelog**
:cl: Kendrick
- fix: Ноги унатхов выпрямились
