### PR TITLE
Понизил кол-во патронов в расширенном магазине безгильзовых

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -88,7 +88,7 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifle
-    capacity: 99
+    capacity: 50 #sunrise-edit
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/10x24.rsi
   - type: MagazineVisuals


### PR DESCRIPTION
## Кратное описание
В 2 раза урезал кол-во патронов в расширенном магазине безгильзовых

## По какой причине
При актуальном хитскане и меткости Сиара и AJ-100, 99 патронов в обойме слишком много, это банально зажим длинной в несколько секунд. Получаем меткий пулемёт, от которого и щит не спасёт

**Changelog**
:cl: Kendrick
- tweak: В расширенном магазине безгильзовых патронов теперь 50 патронов.
