### PR TITLE
КД стяжек боргов

### DIFF
--- a/Resources/Prototypes/_Sunrise/Actions/borg_actions.yml
+++ b/Resources/Prototypes/_Sunrise/Actions/borg_actions.yml
@@ -20,7 +20,7 @@
       components:
       - Cuffable
     canTargetSelf: false
-    useDelay: 15
+    useDelay: 9
     checkCanAccess: true
     range: 2
     event: !type:BorgCuffedActionEvent


### PR DESCRIPTION
## Кратное описание
Уменьшение перезарядки стяжек боргов с 15 до 9 секунд. 

## По какой причине
Сейчас заковать нарушителя, как на СБ юните, так и на миротворце это целая задача и требует высокого скилла, поскольку, например, миротворец сначала пока дождётся пока подействует хлораль, потом по началу очень долгое время этот хлораль вырубает на пару секунд, и весь этот хлораль доджится одной кнопкой "проснуться" что позволяет пошевелиться и не дать себя заковать, и снова вырубиться в сон, а в это время борг должен просто ждать новые стяжки несоразмерно ситуации долго. То же самое и борг СБ. у него есть всего пару секунд доехать до радиуса стан-критованного, переключить модуль, навестись, и то бывает делается всё быстро, а нарушитель всё равно умудряется пошевелиться. Поскольку стяжки нельзя дюпать или что-то подобное абузить, не вижу смысла в столь огромном КД. Скорость связывания не увеличилась, лишь время перезарядки. Потому что максимально странно, что за это время можно повторно повалить нарушителя, а стяжки будут всё ещё в КД. И приходится стоять как дурачок смотреть пока он вновь встанет.



**Changelog**

:cl: iDesmond
- tweak: Перезарядка стяжек боргов уменьшена с 15 до 9 секунд


