### PR TITLE
Кустарное ПНВ теперь хуже чем Обычное

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Eyes/night_vision_device.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Eyes/night_vision_device.yml
@@ -122,3 +122,5 @@
   - type: PowerCellDraw
     drawRate: 0
     useRate: 50
+  - type: VisionDarkener
+    strength: 1


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Кустарное пнв имеет на 2 клетки меньше радиуса обзора
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Кустароное стоит дешевле и я ни разу не видел чтобы станция делало обычно пнв заместо кустарных
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
![image](https://github.com/user-attachments/assets/1c75157c-0408-4424-91bc-4a925d16cf30)
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: Протолат перестал печатать кустарное ПНВ с идеальным изображением. Теперь Кустарное ПНВ действительно кустарное.