### PR TITLE
ПНВ замена алмаза на уран в крафте

### DIFF
--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/devices.yml
@@ -15,8 +15,8 @@
   materials:
     Steel: 1000
     Plastic: 400
-    Silver: 100
-    Diamond: 100
+    Silver: 300
+    Uranium: 100
 
 - type: latheRecipe
   id: BasicThermals
@@ -35,8 +35,8 @@
   - Weapons
   completetime: 30
   materials:
-    Steel: 1200
-    Plasma: 750
+    Steel: 1400
+    Plasma: 800
     Glass: 500
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/devices.yml
@@ -16,7 +16,7 @@
     Steel: 1000
     Plastic: 400
     Silver: 300
-    Uranium: 100
+    Uranium: 300
 
 - type: latheRecipe
   id: BasicThermals


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
ПНВ замена алмаза на уран в крафте 1>1

Немного увеличил стоимость крафта плазма каттеру, так как протокинет был порезан и теперь требует обильного  вложения в улучшения (Скоро Плазма каттер так же будет улучшаться)
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Кустарные должны быть хуже, но их лучшая версия слишкмо дорога и не может конкурировать с термалами из-а одинаковой стоимости
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: создание ПНВ теперь требует уран вместо алмаза.