### PR TITLE
Щит на броню Аколита

### DIFF
--- a/Content.Server/EnergyDome/EnergyDomeSystem.cs
+++ b/Content.Server/EnergyDome/EnergyDomeSystem.cs
@@ -312,7 +312,7 @@ public sealed partial class EnergyDomeSystem : EntitySystem
         }
         if (TryComp<BatterySelfRechargerComponent>(generator, out var recharger))
         {
-            recharger.AutoRecharge = false;
+            recharger.AutoRecharge = true;
         }
 
         _audio.PlayPvs(generator.Comp.TurnOffSound, generator);

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -349,6 +349,19 @@
     tags:
     - FullBodyOuter
     - WhitelistChameleon
+  - type: Battery
+    maxCharge: 40
+    startingCharge: 40
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 40
+    autoRechargePause: true
+    autoRechargePauseTime: 9
+  - type: EnergyDomeGenerator
+    damageEnergyDraw: 1
+    domePrototype: EnergyDomeSmallPink
+  - type: UseDelay
+    delay: 10.0
   # Sunrise-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -359,7 +359,7 @@
     autoRechargePauseTime: 9
   - type: EnergyDomeGenerator
     damageEnergyDraw: 1
-    domePrototype: EnergyDomeSmallPink
+    domePrototype: EnergyDomeCult
   - type: UseDelay
     delay: 10.0
   # Sunrise-End

--- a/Resources/Prototypes/_Sunrise/Entities/Effects/dome.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Effects/dome.yml
@@ -1,0 +1,28 @@
+- type: entity
+  id: EnergyDomeCult
+  categories: [ HideSpawnMenu ]
+  parent: EnergyDomeBase
+  components:
+  - type: Sprite
+    layers:
+      - sprite: _Sunrise/BloodCult/Effects/shield.rsi
+        state: shield-cult
+        shader: unshaded
+    scale: 1.2, 1.2
+  - type: PointLight
+    enabled: true
+    radius: 6
+    power: 3
+    color: "#f5166b"
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.6
+        density: 0
+        mask:
+        - None
+        layer:
+        - BulletImpassable
+        - Opaque


### PR DESCRIPTION
## Кратное описание
Добавлен сферический щит на доспехи культа. Щит выдерживает от 2 до 4 попаданий среднестатистического оружия, технически он на 40хп. Перезаряжается 10 секунд сразу на полную зарядку.  

## По какой причине
https://github.com/space-sunrise/sunrise-station/issues/1649#issue-2970838064
Пока без перезарядки магией крови, так сказал Кайзер. 
Полагаю пока не будет готово это https://github.com/space-sunrise/sunrise-station/issues/1594?issue=space-sunrise%7Csunrise-station%7C1650

## Медиа(Видео/Скриншоты)
![image](https://github.com/user-attachments/assets/62d31c55-9a07-4e94-a47b-92e00f1b2d7b)



**Changelog**

:cl: iDesmond
- add: Доспехи культа теперь имеют лёгкий сферический щит
