### PR TITLE
Парамедик более не антаг. Зато с мониторингом экипажа

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -11,6 +11,7 @@
       time: 36000 # 15 hrs # Sunrise-RoleTime
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
+  canBeAntag: false # Sunrise-Edit
   supervisors: job-supervisors-cmo
   displayWeight: 25  # Sunrise
   access:
@@ -29,3 +30,4 @@
   storage:
     back:
     - EmergencyRollerBedSpawnFolded
+    - HandheldCrewMonitor # Sunrise-Edit


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Парамедик более не антаг. Зато с мониторингом экипажа
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
https://github.com/space-sunrise/sunrise-station/issues/2159
А ещё Вигерс попросил им антагов убрать
![Снимок экрана (3918)](https://github.com/user-attachments/assets/b65ba17d-2cb4-4755-b7da-61a55a92da24)
![Снимок экрана (3919)](https://github.com/user-attachments/assets/263607c9-24ff-4cae-a694-86fe2efb9ecd)


## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
![Снимок экрана (3917)](https://github.com/user-attachments/assets/da4684dd-f7e6-4ca4-9c37-39826ee5824c)

**Changelog**
Парамедики более не могут быть антагонистами, но у них появился портативный мониторинг экипажа 

:cl: Kinar_7
- remove: Нанотрейзен усилила проверку парамедиков. Теперь они не могут быть антагонистами 
- add: Финансирование парамедиков увеличено. Теперь им доступны портативные мониторинги экипажа 

