### PR TITLE
Порезка резистов у хрюшек

### DIFF
--- a/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
@@ -11,10 +11,10 @@
   id: Swine
   coefficients:
     Blunt: 0.5
-    Slash: 0.7
-    Piercing: 0.7
-    Cold: 0.5
-    Heat: 0.5
+    Slash: 0.75
+    Piercing: 0.75
+    Cold: 0.7
+    Heat: 0.75
 
 - type: damageModifierSet
   id: Predator


### PR DESCRIPTION

## Кратное описание
Свинота расхрюкала весь свой запас жира, поэтому резисты были уменьшены


## По какой причине
Слишком имбалансные резисты без каких-либо дебафов.


**Changelog**

:cl: Shiranuy
- tweak: Лето, жир свинкам больше не нужен, резисты были уменьшены.

