### PR TITLE
Улучшение визора сИИ

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -78,6 +78,7 @@
   # Sunrise-Start
   - type: ShowThirstIcons
   - type: ShowHungerIcons
+  - type: ShowHealthIcons
   - type: ShowHealthBars
     damageContainers:
       - Biological

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -75,6 +75,16 @@
     announceVoice: PortalGlados # Sunrise-Edit
     sound: /Audio/_Sunrise/Announcements/announce_dig.ogg # Sunrise-Edit
   - type: ShowJobIcons
+  # Sunrise-Start
+  - type: ShowThirstIcons
+  - type: ShowHungerIcons
+  - type: ShowHealthBars
+    damageContainers:
+      - Biological
+      - Inorganic
+      - Silicon
+      - Mech
+  # Sunrise-End
   - type: Speech # Sunrise-Edit
     speechVerb: Robotic # Sunrise-Edit
 


### PR DESCRIPTION
## Кратное описание
Желание улучшить визор сИИ, добавить больше элементов с других визоров и очков.

## По какой причине
Теперь сИИ сможет видеть здоровье экипажа, живых существ, боргов и мехов. Позволит сИИ лучше определять состояние мобов без их осмотра, наряду с этим откроется больше возможностей для разного рода приказов другим синтетикам, может даже помощи рядовому экипажу. Сможет быстро определить состояние мертвеца, будто гнилой или мертвый с возможностью на возраждение.

## Медиа(Видео/Скриншоты)
![Снимок экрана 2025-05-30 211449](https://github.com/user-attachments/assets/d39d07eb-0704-4f12-a811-7ee1eafe7805)

**Changelog**
:cl: Gardsnake
- add: Улучшение визора сИИ, теперь он может видеть голод, жажду и полоску здоровья у членов экипажа, мехов, боргов и живых существ.