### PR TITLE
Артефакты-предметы, смешной хаос и не только

### DIFF
--- a/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Body.Organ;
 using Content.Shared.GameTicking;
 using Content.Shared.Item;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
+using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
 using IConfigurationManager = Robust.Shared.Configuration.IConfigurationManager;
 using Robust.Shared.Prototypes;
 
@@ -112,6 +113,9 @@ public sealed class RandomXenoArtifactsSystem : EntitySystem
             return;
 
         EntityManager.AddComponents(ent, _baseParentPrototype!.Components, false);
+
+        // Чтобы не давать лишние подсказки, ибо не прикол
+        RemComp<XATExaminableTextComponent>(ent);
     }
 
     /// <summary>

--- a/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
@@ -109,9 +109,6 @@ public sealed class RandomXenoArtifactsSystem : EntitySystem
 
     private void MakeArtifact(Entity<ItemComponent> ent)
     {
-        if (!Exists(ent))
-            return;
-
         EntityManager.AddComponents(ent, _baseParentPrototype!.Components, false);
 
         // Чтобы не давать лишние подсказки, ибо не прикол

--- a/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
@@ -142,7 +142,7 @@ public sealed class RandomXenoArtifactsSystem : EntitySystem
 
         if (!enabled)
         {
-            var items = _helpers.GetAll<ItemComponent, XenoArtifactComponent>();
+            var items = _helpers.GetAll<XenoArtifactRandomItemMarkerComponent>();
 
             foreach (var item in items)
             {

--- a/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
 using IConfigurationManager = Robust.Shared.Configuration.IConfigurationManager;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Server._Sunrise.Xenoarchaeology;
 
@@ -17,6 +18,7 @@ public sealed class RandomXenoArtifactsSystem : EntitySystem
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly SunriseHelpersSystem _helpers = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IConfigurationManager _configuration = default!;
 
     /// <summary>
@@ -75,7 +77,9 @@ public sealed class RandomXenoArtifactsSystem : EntitySystem
 
         var items = _helpers.GetAll<ItemComponent>()
             .Where(e => IsAppropriate(e.Owner))
-            .ToHashSet();
+            .ToList();
+
+        _random.Shuffle(items);
 
         var reducedItems = _helpers.GetPercentageOfHashSet(items, _itemToArtifactRatio);
 
@@ -110,9 +114,6 @@ public sealed class RandomXenoArtifactsSystem : EntitySystem
     private void MakeArtifact(Entity<ItemComponent> ent)
     {
         EntityManager.AddComponents(ent, _baseParentPrototype!.Components, false);
-
-        // Чтобы не давать лишние подсказки, ибо не прикол
-        RemComp<XATExaminableTextComponent>(ent);
     }
 
     /// <summary>

--- a/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
@@ -1,0 +1,158 @@
+﻿using System.Linq;
+using Content.Server._Sunrise.Helpers;
+using Content.Server.Station.Systems;
+using Content.Shared._Sunrise.SunriseCCVars;
+using Content.Shared.Body.Organ;
+using Content.Shared.GameTicking;
+using Content.Shared.Item;
+using Content.Shared.Xenoarchaeology.Artifact.Components;
+using IConfigurationManager = Robust.Shared.Configuration.IConfigurationManager;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Sunrise.Xenoarchaeology;
+
+public sealed class RandomXenoArtifactsSystem : EntitySystem
+{
+    [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly SunriseHelpersSystem _helpers = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+
+    /// <summary>
+    /// Соотношение предметов к предметам-артефактам. В % процентах.
+    /// Стандартное соотношение: <see cref="SunriseCCVars.ItemToArtifactRatio"/>
+    /// </summary>
+    private float _itemToArtifactRatio;
+    private bool _enabled = SunriseCCVars.EnableRandomArtifacts.DefaultValue;
+
+    private static readonly EntProtoId BaseParent = "BaseRandomItemXenoArtifactComponents";
+    private static EntityPrototype? _baseParentPrototype;
+
+    private EntityQuery<TransformComponent> _xform;
+    private EntityQuery<OrganComponent> _organs;
+
+    private ISawmill _sawmill = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _configuration.OnValueChanged(SunriseCCVars.EnableRandomArtifacts, OnCvarChanged, true);
+        _configuration.OnValueChanged(SunriseCCVars.ItemToArtifactRatio, r => _itemToArtifactRatio = r, true);
+
+        SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
+
+        _xform = GetEntityQuery<TransformComponent>();
+        _organs = GetEntityQuery<OrganComponent>();
+
+        _sawmill = Logger.GetSawmill("sunrise.random_artifacts");
+    }
+
+    private void OnRoundStarted(RoundStartedEvent ev)
+    {
+        if (!_enabled)
+            return;
+
+        DeleteOldArtifacts();
+        CreateRandomArtifacts();
+    }
+
+    #region Creation
+
+    /// <summary>
+    /// Превращает часть предметов в артефакты
+    /// Количество зависит от выставленного значения в <see cref="SunriseCCVars.ItemToArtifactRatio"/>
+    /// </summary>
+    public void CreateRandomArtifacts()
+    {
+        if (!_prototype.TryIndex(BaseParent, out _baseParentPrototype))
+        {
+            _sawmill.Error("Error while creating BaseParent for RandomXenoArtifactsSystem");
+
+            return;
+        }
+
+        var items = _helpers.GetAll<ItemComponent>()
+            .Where(e => IsAppropriate(e.Owner))
+            .ToHashSet();
+
+        var reducedItems = _helpers.GetPercentageOfHashSet(items, _itemToArtifactRatio);
+
+        foreach (var item in reducedItems)
+        {
+            MakeArtifact(item);
+        }
+
+        _sawmill.Debug($"{reducedItems.Count()} made into artifacts");
+    }
+
+    /// <summary>
+    /// Проверяет, подходит ли выбранный предмет для превращения в артефакт-предмет
+    /// </summary>
+    private bool IsAppropriate(Entity<TransformComponent?> ent)
+    {
+        if (!_xform.Resolve(ref ent))
+            return false;
+
+        var station = _station.GetOwningStation(ent, ent.Comp);
+
+        if (!HasComp<StationRandomXenoArtifactComponent>(station))
+            return false;
+
+        // Чтобы органы внутри персонажей не становились артефактами
+        if (_organs.HasComp(ent))
+            return false;
+
+        return true;
+    }
+
+    private void MakeArtifact(Entity<ItemComponent> ent)
+    {
+        if (!Exists(ent))
+            return;
+
+        EntityManager.AddComponents(ent, _baseParentPrototype!.Components, false);
+    }
+
+    /// <summary>
+    /// Удаляет старые артефакты.
+    /// Теперь только предметы
+    /// </summary>
+    private void DeleteOldArtifacts()
+    {
+        var query = AllEntityQuery<XenoArtifactComponent>();
+
+        while (query.MoveNext(out var uid, out _))
+        {
+            QueueDel(uid);
+        }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Обрабатывает изменение текущих настроек сервера.
+    /// Поддерживает переключение в моменте игры
+    /// </summary>
+    private void OnCvarChanged(bool enabled)
+    {
+        if (_enabled == enabled)
+            return;
+
+        if (!enabled)
+        {
+            var items = _helpers.GetAll<ItemComponent, XenoArtifactComponent>();
+
+            foreach (var item in items)
+            {
+                RemComp<XenoArtifactComponent>(item);
+            }
+        }
+        else
+        {
+            CreateRandomArtifacts();
+        }
+
+        _enabled = enabled;
+    }
+}

--- a/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/RandomXenoArtifactsSystem.cs
@@ -6,8 +6,7 @@ using Content.Shared.Body.Organ;
 using Content.Shared.GameTicking;
 using Content.Shared.Item;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
-using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
-using IConfigurationManager = Robust.Shared.Configuration.IConfigurationManager;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 

--- a/Content.Server/_Sunrise/Xenoarchaeology/StationRandomXenoArtifactComponent.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/StationRandomXenoArtifactComponent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Server._Sunrise.Xenoarchaeology;
+
+[RegisterComponent]
+public sealed partial class StationRandomXenoArtifactComponent : Component;

--- a/Content.Server/_Sunrise/Xenoarchaeology/XenoArtifactRandomItemMarkerComponent.cs
+++ b/Content.Server/_Sunrise/Xenoarchaeology/XenoArtifactRandomItemMarkerComponent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Server._Sunrise.Xenoarchaeology;
+
+/// <summary>
+/// Класс-маркер, используемый для обозначения, что артефакт является случайным предметом и сделан с помощью системы случайных-артефактов
+/// </summary>
+[RegisterComponent]
+public sealed partial class XenoArtifactRandomItemMarkerComponent : Component;

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
@@ -445,4 +445,20 @@ public sealed partial class SunriseCCVars : CVars
     /// </summary>
     public static readonly CVarDef<int> ArrivalsMinHours =
         CVarDef.Create("transithub.arrivals_min_hours", 0, CVar.SERVER | CVar.ARCHIVE);
+
+    /*
+     * Random items-artifacts
+     */
+
+    /// <summary>
+    /// Включены ли артефакты-предметы? Переключение этого в моменты игры динамически включает и выключает фичу
+    /// </summary>
+    public static readonly CVarDef<bool> EnableRandomArtifacts =
+        CVarDef.Create("random_artifacts.enable", true, CVar.SERVER | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Соотношение артефактов-предметов к обычным предметам.
+    /// </summary>
+    public static readonly CVarDef<float> ItemToArtifactRatio =
+        CVarDef.Create("random_artifacts.ratio", 0.55f, CVar.SERVER | CVar.ARCHIVE);
 }

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -37,6 +37,7 @@
     - BaseStationAntagsTargets
     - BaseStationCryoTeleport
     - BaseStationMeteorSwarmTarget
+    - BaseStationRandomXenoArtifact
   # Sunrise-End
   components:
     - type: Transform

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -191,8 +191,9 @@
   components:
   - type: XATToolUse
     requiredTool: Anchoring
-  - type: XATExaminableText
-    examineText: xenoarch-trigger-examine-wrenching
+  # Sunrise edit - не нужно
+  #- type: XATExaminableText
+  #  examineText: xenoarch-trigger-examine-wrenching
 
 - type: xenoArchTrigger
   id: TriggerPrying
@@ -200,8 +201,9 @@
   components:
   - type: XATToolUse
     requiredTool: Prying
-  - type: XATExaminableText
-    examineText: xenoarch-trigger-examine-prying
+  # Sunrise edit - не нужно
+  #- type: XATExaminableText
+  #  examineText: xenoarch-trigger-examine-prying
 
 - type: xenoArchTrigger
   id: TriggerScrewing
@@ -209,8 +211,9 @@
   components:
   - type: XATToolUse
     requiredTool: Screwing
-  - type: XATExaminableText
-    examineText: xenoarch-trigger-examine-screwing
+  # Sunrise edit - не нужно
+  #- type: XATExaminableText
+  #  examineText: xenoarch-trigger-examine-screwing
 
 - type: xenoArchTrigger
   id: TriggerPulsing
@@ -218,8 +221,9 @@
   components:
   - type: XATToolUse
     requiredTool: Pulsing
-  - type: XATExaminableText
-    examineText: xenoarch-trigger-examine-pulsing
+  # Sunrise edit - не нужно
+  #- type: XATExaminableText
+  #  examineText: xenoarch-trigger-examine-pulsing
 
 - type: xenoArchTrigger
   id: TriggerTimer

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Xenoarchaelogy/xenoartifacts.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Xenoarchaelogy/xenoartifacts.yml
@@ -1,0 +1,32 @@
+﻿- type: entity
+  id: BaseRandomItemXenoArtifactComponents
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: XenoArtifact
+    nodeCount:
+      min: 9
+      max: 13
+    effectsTable: !type:GroupSelector
+      children:
+      - !type:NestedSelector
+        tableId: SunriseArtifactEffectsDefaultTable
+        weight: 3
+      - !type:NestedSelector
+        tableId: SunriseArtifactEffectsVanillaDefaultReducedTable
+        weight: 3
+      - !type:NestedSelector
+        tableId: SunriseArtifactEffectsUltraFunnyTable
+        weight: 1
+  - type: Damageable
+  - type: ContainerContainer
+    containers:
+      node-container: !type:Container
+        showEnts: False
+        occludes: True
+        ents: []
+  - type: RadiationReceiver
+  - type: Reactive
+    groups:
+      Flammable: [Touch]
+      Extinguish: [Touch]
+      Acidic: [Touch]

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Xenoarchaelogy/xenoartifacts.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Xenoarchaelogy/xenoartifacts.yml
@@ -30,3 +30,4 @@
       Flammable: [Touch]
       Extinguish: [Touch]
       Acidic: [Touch]
+  - type: XenoArtifactRandomItemMarker

--- a/Resources/Prototypes/_Sunrise/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Stations/base.yml
@@ -96,3 +96,9 @@
   abstract: true
   components:
   - type: StationMeteorSwarmTarget
+
+- type: entity
+  id: BaseStationRandomXenoArtifact
+  abstract: true
+  components:
+  - type: StationRandomXenoArtifact

--- a/Resources/Prototypes/_Sunrise/Research/Artifact/tables.yml
+++ b/Resources/Prototypes/_Sunrise/Research/Artifact/tables.yml
@@ -158,7 +158,7 @@
     TriggerPrying: 1
     TriggerScrewing: 1
     TriggerPulsing: 1
-    TriggerTimer: 0.25
+    TriggerTimer: 1 # Sunrise edit - для артефактов предметов. Чтобы виднее были
     TriggerBlood: 1
     TriggerThrow: 1
     TriggerDeath: 1


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Теперь стандартных артефактов на станции раундстартом не будет. Все артефакты будут являться предметами, которые иногда будут проявлять свои аномальные способности
Ученым нужно будет ходить по станции и искать аномальные предметы. А экипажу помогать ученым и вызывать, если хирургический скальпель взорвался

Больше хаоса и приколов.

**Changelog**

:cl: ThereDrD
- add: Переработаны артефакты. Теперь случайное небольшое количество предметов становится артефактами со случайными эффектами. Ученым теперь требуется искать артефакты на станции, а экипажу вызывать бригаду ликвидаторов, если хирургический скальпель решит взорваться. Админы могут прописать команду xenoartifact:list, чтобы увидеть все артефакты-предметы.
- tweak: Увеличен шанс триггера-таймера, чтобы артефакты-предметы были виднее
- remove: Стандартные статичные артефакты будут удаляться, когда включены артефакты предметы.
