### PR TITLE
Увеличено время до вызова шаттла

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -83,7 +83,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Time crew can't call emergency shuttle after war declaration.
     /// </summary>
     [DataField]
-    public TimeSpan WarEvacShuttleDisabled = TimeSpan.FromMinutes(25);
+    public TimeSpan WarEvacShuttleDisabled = TimeSpan.FromMinutes(30);
 
     /// <summary>
     ///     Minimal operatives count for war declaration

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -83,7 +83,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Time crew can't call emergency shuttle after war declaration.
     /// </summary>
     [DataField]
-    public TimeSpan WarEvacShuttleDisabled = TimeSpan.FromMinutes(30);
+    public TimeSpan WarEvacShuttleDisabled = TimeSpan.FromMinutes(30); // Sunrise-edit
 
     /// <summary>
     ///     Minimal operatives count for war declaration


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Увеличил время вызова шаттла с 25 минут до 30 при обьявлении войны
Фактически это изменения 10 минут когда оперативники уже на станции на 15 минут, что по идеи даст время на заполучение диска и подальшие действия оперативников (Подрыв Бомбы на ЦК,Побег экипажа с диском на ЦК и прочие варианты события)

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Глупые Адмемы что считают за нарушение вызов шаттла при Геймруле Оперативников
Дополнительный стимул оперативников работать быстро а не вырезать станцию пока станция не имеет право покидать станцию из-за **правил**
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: Задержка вызова эвакуационного шаттла теперь состовляет 30 минус заместо 25 при объявлении войны. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения**
  - Увеличено время блокировки вызова аварийного шаттла после объявления войны с 25 до 30 минут.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->