### PR TITLE
Уменьшение снотворного у транквилизаторах

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -162,9 +162,9 @@
       ammo:
         reagents:
         - ReagentId: ChloralHydrate
-          Quantity: 15
+          Quantity: 9
   - type: SolutionInjectOnProjectileHit
-    transferAmount: 15
+    transferAmount: 9
     solution: ammo
   - type: SpentAmmoVisuals
     state: "tranquilizer"


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Уменьшение снотворного у транквилизаторах
15>9 (Оффы 7)

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Два попадания сейчас уже гарантированный сон через 10 секунд и ещё 35 урона ядами
Причем патроны хитскан
Теперь два патрона будут давать в суме 18 химиката от чего урона не будет, третий же начнет наносить урон но и он будет меньше

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: NT уменьшило дозу снотворного в транквилизаторах для уменьшения летальных случаев.