### PR TITLE
Fix EmitSoundOnWearerMoveSystem.cs

### DIFF
--- a/Content.Shared/_Sunrise/Clothing/EntitySystems/EmitSoundOnWearerMoveSystem.cs
+++ b/Content.Shared/_Sunrise/Clothing/EntitySystems/EmitSoundOnWearerMoveSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Movement.Components;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Configuration;
 using Robust.Shared.Physics.Components;
 
 namespace Content.Shared._Sunrise.Clothing.EntitySystems;
@@ -47,7 +46,7 @@ public sealed class EmitSoundOnWearerMoveSystem : EntitySystem
                        clothing.InSlot != null &&
                        emitSoundOnMoveComponent.IsValidSlot;
 
-            var coords = xform.Coordinates;
+            var coords = Transform(wearer).Coordinates;
             var dist = (worn && _inputMover.TryGetComponent(wearer, out var mover) && mover.Sprinting)
                 ? MinDistanceSprinting
                 : MinDistanceWaling;


### PR DESCRIPTION
ДРД пока ревьюил дал АХУЕННУЮ (нет) идею использовать координаты самого итема для рассчета расстояния. Только вот не учел он одно НО: когда айтем в инвентаре у него координаты <id носителя>, Y: 0, X: 0. И они не меняются. Так что вот исправление

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения**
  - Улучшено определение расстояния для воспроизведения звука при движении: теперь расчет ведется относительно координат носителя одежды, а не самой одежды.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->