### PR TITLE
Медик. Носи свой скаф!

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -579,6 +579,23 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
+  - type: ExplosionResistance #Sunrise-start
+    damageCoefficient: 0.35
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
+        Radiation: 0.25
+        Caustic: 0.25
+        Bloodloss: 0.5
+  - type: FireProtection
+    reduction: 0.5
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.75
+#Sunrise-end
 
 #Syndicate Elite Hardsuit
 - type: entity

--- a/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
@@ -672,7 +672,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndiemedic.rsi, state: icon }
   productEntity: ClothingOuterHardsuitSyndieMedicBiocode
   cost:
-    Telecrystal: 8
+    Telecrystal: 9
   categories:
   - UplinkWearables
   conditions:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Небольшой баф от части не боевых параметров скафандра медика
Добавил защиту в 50% от Кровопотери, работает по тестам заметно только в долгосрочную перспективу в бою, минут через 2-5 если не лечить кровотечение.
уменьшен урон от горения, игрок меньше получает урона если загориться, заметно только если не тушиться пол минуты

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Хочу чтобы медики носили свои скафандры чаще, ведь это быстрое отличие в команде и визитная карточка медика

Добавил меньший штраф замедление от урона, пол тайла скорости выигрывает при 55+ уроне
Сильно повысил защиту от радиации и кислоты а так же защиту от взрыва, не боевая защита  (Кислота и рада) нацеленная на сохранность игрока и медика команды от  нестандартных вещей по типу мудака с урановым копьем, безумца на СИ с кусками СМа или Шахида Химика.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
![image](https://github.com/user-attachments/assets/53f85ecb-11e6-40c0-a243-f92cc9ee084a)

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
