### PR TITLE
Расширил лодаут оружия СБух

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Misc/acp14box.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Misc/acp14box.yml
@@ -1,0 +1,25 @@
+- type: entity
+  parent: BaseStorageItem
+  id: ACP14Box
+  name: ACP14 box
+  description: It contains a ACP14 and a magazine for it. Did you want something else?
+  components:
+  - type: Sprite
+    sprite: _Sunrise/Objects/Storage/glockbox.rsi
+    layers:
+    - state: icon
+  - type: Item
+    sprite: _Sunrise/Objects/Storage/glockbox.rsi
+    heldPrefix: glockb
+    size: Normal
+    shape:
+    - 0,0,2,1
+  - type: Storage
+    grid:
+    - 0,0,2,1
+  - type: StorageFill
+    contents:
+      - id: MagazineACP14
+        amount: 1
+      - id: WeaponPistolACP14
+        amount: 1

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Misc/hibrowningbox.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Misc/hibrowningbox.yml
@@ -1,0 +1,25 @@
+- type: entity
+  parent: BaseStorageItem
+  id: HIBrowningBox
+  name: HIBrowning box
+  description: It contains a HIBrowning-88 М4 and a magazine for it. Did you want something else?
+  components:
+  - type: Sprite
+    sprite: _Sunrise/Objects/Storage/glockbox.rsi
+    layers:
+    - state: icon
+  - type: Item
+    sprite: _Sunrise/Objects/Storage/glockbox.rsi
+    heldPrefix: glockb
+    size: Normal
+    shape:
+    - 0,0,2,1
+  - type: Storage
+    grid:
+    - 0,0,2,1
+  - type: StorageFill
+    contents:
+      - id: WeaponPistolHIB88M4
+        amount: 1
+      - id: MagazineHIBrowning
+        amount: 1

--- a/Resources/Prototypes/_Sunrise/Loadouts/Jobs/Security/security.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Jobs/Security/security.yml
@@ -97,3 +97,63 @@
   storage:
     back:
     - HoloprojectorSecurity
+
+- type: loadout
+  id: GlockBox
+  startingGear: GlockBox
+
+- type: startingGear
+  id: GlockBox
+  storage:
+    back:
+    - GlockBox
+
+- type: loadout
+  id: HIBrowningBox
+  startingGear: HIBrowningBox
+
+- type: startingGear
+  id: HIBrowningBox
+  storage:
+    back:
+    - HIBrowningBox
+
+- type: loadout
+  id: ACP14Box
+  startingGear: ACP14Box
+
+- type: startingGear
+  id: ACP14Box
+  storage:
+    back:
+    - ACP14Box
+
+- type: loadout
+  id: WeaponEnergyGunPistolSecurity
+  startingGear: WeaponEnergyGunPistolSecurity
+
+- type: startingGear
+  id: WeaponEnergyGunPistolSecurity
+  storage:
+    back:
+    - WeaponEnergyGunPistolSecurity
+
+- type: loadout
+  id: WeaponDisabler
+  startingGear: WeaponDisabler
+
+- type: startingGear
+  id: WeaponDisabler
+  storage:
+    back:
+    - WeaponDisabler
+
+- type: loadout
+  id: WeaponTaser
+  startingGear: WeaponTaser
+
+- type: startingGear
+  id: WeaponTaser
+  storage:
+    back:
+    - WeaponTaser

--- a/Resources/Prototypes/_Sunrise/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/loadout_groups.yml
@@ -221,9 +221,12 @@
   minLimit: 1
   maxLimit: 1
   loadouts:
-  #- SunriseWeaponPistolG22
-  - SunriseWeaponEnergyGun
-  - SunriseWeaponTaser
+  - GlockBox
+  - HIBrowningBox
+  - ACP14Box 
+  - WeaponEnergyGunPistolSecurity
+  - WeaponDisabler
+  - WeaponTaser
 
 # Security  HoS
 - type: loadoutGroup


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Лодаут СБшников расширен. Я вернул Глок22. Я так же добавил аналоги глока с такими характеристиками как у него, APC14 и какое-то непроизносимое говно HIB88M4
## По какой причине
Я хз зачем убрали их святой табельный Глок22. 
## Медиа(Видео/Скриншоты)
![Снимок экрана (4043)](https://github.com/user-attachments/assets/8b957a52-9164-4776-b2b8-7710f7ffe8cc)


**Changelog**
:cl: Kinar_7
- tweak: Изменен лодаут СБшников. Теперь там есть Глок22 и его аналоги.


