### PR TITLE
Исправления панели телепорта призрака

### DIFF
--- a/Content.Client/_Sunrise/UserInterface/Systems/Ghost/Controls/SunriseGhostTargetWindow.xaml.cs
+++ b/Content.Client/_Sunrise/UserInterface/Systems/Ghost/Controls/SunriseGhostTargetWindow.xaml.cs
@@ -109,10 +109,10 @@ public sealed partial class SunriseGhostTargetWindow : DefaultWindow
                 _deadPlayers.Add(warp);
             else if (warp.IsLeft) // Ливнувшие
                 _leftPlayers.Add(warp);
-            else if (!warp.IsDead) // Живые. Как в крите, так и полноценное живые
-                _alivePlayers.Add(warp);
             else if (warp.IsGhost) // Призраки
                 _ghostPlayers.Add(warp);
+            else if (!warp.IsDead) // Живые. Как в крите, так и полноценное живые
+                _alivePlayers.Add(warp);
         }
     }
 }


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Призраки попали под невозможное условие, где человек считался либо мертвый, не мертвый. Очевидно, что дальше условие не шло

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: ThereDrD
- fix: Исправлено отображение призраков как живых в панели призрака
- fix: Мобы, в которых находятся или были игроки теперь так же отображаются в панели призрака


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Исправления ошибок**
	- Улучшена корректность распределения игроков по категориям «живой», «призрак», «мертвый» и «покинул», что обеспечивает более точное отображение статуса игроков в интерфейсе.
	- Повышена точность отображения доступных для телепортации сущностей в панели призраков за счёт учёта состояний мобов и исключения неигровых мобов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->