### PR TITLE
Перемещено логгирование PowerNetSystem и AtmosphereSystem в Debug

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -114,7 +114,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
 
         if (_frameCount % 100 == 0)
         {
-            Logger.Info($"AtmosphereSystem: Last frame time: {_lastFrameTime:F2}ms, Average frame time: {_averageFrameTime:F2}ms");
+            Logger.Debug($"AtmosphereSystem: Last frame time: {_lastFrameTime:F2}ms, Average frame time: {_averageFrameTime:F2}ms"); // Sunrise-edit
         }
 
         _exposedTimer += frameTime;

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -307,7 +307,7 @@ namespace Content.Server.Power.EntitySystems
 
             if (_frameCount % 100 == 0)
             {
-                Logger.Info($"PowerNetSystem: Last frame time: {_lastFrameTime:F2}ms, Average frame time: {_averageFrameTime:F2}ms");
+                Logger.Debug($"PowerNetSystem: Last frame time: {_lastFrameTime:F2}ms, Average frame time: {_averageFrameTime:F2}ms"); // Sunrise-edit
             }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Стиль**
	- Изменён уровень детализации логирования некоторых сообщений о производительности: теперь они отображаются только при включённом режиме отладки и не будут видны обычным пользователям.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->