### PR TITLE
Улучшение системы заточки

### DIFF
--- a/Content.Server/_Sunrise/SharpeningSystem/SharpenerComponent.cs
+++ b/Content.Server/_Sunrise/SharpeningSystem/SharpenerComponent.cs
@@ -5,9 +5,16 @@ namespace Content.Server._Sunrise.SharpeningSystem;
 [RegisterComponent]
 public sealed partial class SharpenerComponent : Component
 {
+    /// <summary>
+    /// Sunrise - Edit
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
-    public DamageSpecifier DamageBonus;
+    public DamageSpecifier SlashDamageBonus = new();
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
+    public DamageSpecifier PiercingDamageBonus = new();
 
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]

--- a/Content.Server/_Sunrise/SharpeningSystem/SharpeningSystem.cs
+++ b/Content.Server/_Sunrise/SharpeningSystem/SharpeningSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Item;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Damage;
 
 namespace Content.Server._Sunrise.SharpeningSystem;
 
@@ -39,8 +40,8 @@ public sealed class SharpeningSystem : EntitySystem
             _popupSystem.PopupEntity(Loc.GetString("sharpening-failed"), target, args.User);
             return;
         }
-
-        if (!meleeWeaponComponent.Damage.DamageDict.ContainsKey("Slash"))
+        /// Sunrise - Edit
+        if (!meleeWeaponComponent.Damage.DamageDict.ContainsKey("Slash") && !meleeWeaponComponent.Damage.DamageDict.ContainsKey("Piercing"))
         {
             _popupSystem.PopupEntity(Loc.GetString("sharpening-failed-blade"), target, args.User);
             return;
@@ -58,7 +59,15 @@ public sealed class SharpeningSystem : EntitySystem
             return;
         }
 
-        EnsureComp<SharpenedComponent>(target).DamageBonus = component.DamageBonus;
+        /// Sunrise - Edit
+        var damageBonus = new DamageSpecifier();
+
+        if (meleeWeaponComponent.Damage.DamageDict.ContainsKey("Piercing"))
+            damageBonus = component.PiercingDamageBonus;
+        else if (meleeWeaponComponent.Damage.DamageDict.ContainsKey("Slash"))
+            damageBonus = component.SlashDamageBonus;
+
+        EnsureComp<SharpenedComponent>(target).DamageBonus = damageBonus;
 
         component.Usages -= 1;
 

--- a/Resources/Prototypes/_Sunrise/BloodCult/Object/wetstone.yml
+++ b/Resources/Prototypes/_Sunrise/BloodCult/Object/wetstone.yml
@@ -3,9 +3,13 @@
   parent: BaseItem
   components:
     - type: Sharpener
-      damageBonus:
+      # Sunrise - Edit
+      slashDamageBonus:
         types:
           Slash: 5
+      piercingDamageBonus:
+        types:
+          Piercing: 3
     - type: Sprite
       sprite: _Sunrise/BloodCult/Entities/wetstone.rsi
       layers:
@@ -26,9 +30,12 @@
   id: CultSharpener
   components:
     - type: Sharpener
-      damageBonus:
+      slashDamageBonus:
         types:
           Slash: 15
+      piercingDamageBonus:
+        types:
+          Piercing: 8
     - type: Sprite
       sprite: _Sunrise/BloodCult/Entities/wetstone.rsi
       layers:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Изменена система заточки - теперь точильными камнями можно так-же заточить оружие ближнего боя которое наносит урон уколами.

## По какой причине
Нелогично что те же копья нельзя заточить

**Changelog**
:cl: Shiranuy
- tweak: Теперь точильные камни могут также затачивать копья и прочее колющее оружие ближнего боя.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Точилки теперь поддерживают два типа бонусов урона: для режущего и колющего оружия.
	- Острота может быть применена как к оружию с режущим, так и с колющим уроном.

- **Изменения баланса**
	- Для точильных камней и культовых точил добавлены отдельные значения бонусов для режущего и колющего урона.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->