### PR TITLE
Изменения в биогенераторе

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/biogen.yml
@@ -20,6 +20,10 @@
   - BioGenLeft4Zed
   - BioGenEZNutrient
   - BioGenRobustHarvest
+  - BioGenUnstableMutagen #Sunrise-add
+  - BioGenNitroKill #Sunrise-add
+  - BioGenInc #Sunrise-add
+  - BioGenDiethylamine #Sunrise-add
 
 - type: latheRecipePack
   id: BioGenMaterialsStatic

--- a/Resources/Prototypes/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/biogen.yml
@@ -5,7 +5,7 @@
   - Food
   completetime: 3
   materials:
-    Biomass: 70
+    Biomass: 30 # Sunrise-Edit
 
 - type: latheRecipe
   id: BioGenKoboldCube
@@ -14,7 +14,7 @@
   - Food
   completetime: 3
   materials:
-    Biomass: 70
+    Biomass: 30 # Sunrise-Edit
 
 - type: latheRecipe
   id: BioGenMaterialCloth1
@@ -257,7 +257,7 @@
   - Materials
   completetime: 3
   materials:
-    Biomass: 100
+    Biomass: 75
 
 - type: latheRecipe
   id: BioClothingBeltPlant
@@ -266,7 +266,7 @@
   - Materials
   completetime: 5
   materials:
-    Biomass: 50
+    Biomass: 20
 
 - type: latheRecipe
   id: BioClothingBeltUtility
@@ -275,7 +275,7 @@
   - Materials
   completetime: 5
   materials:
-    Biomass: 50
+    Biomass: 20
 
 - type: latheRecipe
   id: BioClothingBeltMedical
@@ -284,7 +284,7 @@
   - Materials
   completetime: 5
   materials:
-    Biomass: 50
+    Biomass: 20
 
 - type: latheRecipe
   id: BioClothingBeltJanitor
@@ -293,7 +293,7 @@
   - Materials
   completetime: 5
   materials:
-    Biomass: 50
+    Biomass: 20
 
 - type: latheRecipe
   id: BioClothingBeltStorageWaistbag
@@ -302,7 +302,7 @@
   - Materials
   completetime: 5
   materials:
-    Biomass: 50
+    Biomass: 20
 
 - type: latheRecipe
   id: BioClothingBeltChef
@@ -311,19 +311,19 @@
   - Materials
   completetime: 5
   materials:
-    Biomass: 50
+    Biomass: 20
 
 - type: latheRecipe
   id: BioCowCube
   result: CowCube
-  completetime: 30
+  completetime: 3
   materials:
     Biomass: 240
 
 - type: latheRecipe
   id: BioGoatCube
   result: GoatCube
-  completetime: 30
+  completetime: 3
   materials:
     Biomass: 75
 
@@ -337,28 +337,81 @@
 - type: latheRecipe
   id: BioMouseCube
   result: MouseCube
-  completetime: 15
+  completetime: 3
   materials:
     Biomass: 12
 
 - type: latheRecipe
   id: BioCockroachCube
   result: CockroachCube
-  completetime: 15
+  completetime: 3
   materials:
     Biomass: 16
 
 - type: latheRecipe
   id: BioPigCube
   result: PigCube
-  completetime: 15
+  completetime: 3
   materials:
     Biomass: 55
 
 - type: latheRecipe
   id: BioChikenCube
   result: ChikenCube
-  completetime: 15
+  completetime: 3
   materials:
     Biomass: 16
+
+- type: latheRecipe
+  id: BioGenUnstableMutagen
+  resultReagents:
+    UnstableMutagen: 10
+  categories:
+  - Chemicals
+  icon:
+    sprite: Objects/Specific/Chemistry/bottle.rsi
+    state: bottle-1
+  completetime: 1
+  materials:
+    Biomass: 40
+
+- type: latheRecipe
+  id: BioGenNitroKill
+  resultReagents:
+    NitroKill: 10
+  categories:
+  - Chemicals
+  icon:
+    sprite: Objects/Specific/Chemistry/bottle.rsi
+    state: bottle-1
+  completetime: 1
+  materials:
+    Biomass: 30
+
+- type: latheRecipe
+  id: BioGenInc
+  resultReagents:
+    Inc: 10
+  categories:
+  - Chemicals
+  icon:
+    sprite: Objects/Specific/Chemistry/bottle.rsi
+    state: bottle-1
+  completetime: 1
+  materials:
+    Biomass: 2
+
+- type: latheRecipe
+  id: BioGenDiethylamine
+  resultReagents:
+    Diethylamine: 10
+  categories:
+  - Chemicals
+  icon:
+    sprite: Objects/Specific/Chemistry/bottle.rsi
+    state: bottle-1
+  completetime: 1
+  materials:
+    Biomass: 30
+
 # Sunrise-End

--- a/Resources/Prototypes/_Sunrise/Reagents/botany.yml
+++ b/Resources/Prototypes/_Sunrise/Reagents/botany.yml
@@ -1,0 +1,14 @@
+- type: reagent
+  id: NitroKill
+  name: reagent-name-nitrokill
+  group: Botanical
+  desc: reagent-desc-nitrokill
+  physicalDesc: reagent-physical-desc-strong-smelling
+  flavor: bitter
+  color: "#cbff0e"
+  plantMetabolism:
+  - !type:PlantAdjustHealth
+    amount: -2
+  - !type:PlantAffectGrowth
+    probability: 0.7
+    amount: 1

--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/biogen.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/biogen.yml
@@ -1,5 +1,4 @@
 ## Static
-
 - type: latheRecipePack
   id: BioGenStaticSunrise
   recipes:


### PR DESCRIPTION
## Краткое описание
Биогенератор подвергся изменениям:
- Теперь на нём можно производить чернила для принтера, мутаген, диэтиламин
- Изменена цена мешка с землей по причине наплака и неиспользования игроками
- Добавлен новый химикат из ишуя 
https://github.com/space-sunrise/sunrise-station/issues/1959

**Changelog**

:cl: temm1ie
- add: Nanotrasen провело улучшение своих биогенераторов. Теперь в них можно создавать чернила для принтера, нестабильный мутаген и диэтиламин.
- add: В биогенератор был добавлен новый химикат ускоряющий рост растений. Но будьте осторожны! Он крайне токсичен и способен на раз два убить растение если переборщить.
- add: Цена мешка земли изменена: 100 > 75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Добавлены четыре новых рецепта для получения химических реагентов: UnstableMutagen, NitroKill, Inc и Diethylamine на биогенераторе.
	- Введён новый реагент NitroKill с уникальными эффектами для растений.

- **Улучшения**
	- Значительно снижены требования по биомассе для ряда рецептов биогенератора.
	- Существенно сокращено время изготовления для нескольких рецептов животных кубов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->