### PR TITLE
Немного изменил оружие тяж борга

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Robotics/borg_tools.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Robotics/borg_tools.yml
@@ -510,15 +510,13 @@
     - FullAuto
   - type: HitscanBatteryAmmoProvider
     proto: BulletSyndiPlasmaDouble
-    fireCost: 25
+    fireCost: 50
   - type: Battery
-    maxCharge: 5000
-    startingCharge: 5000
+    maxCharge: 10000
+    startingCharge: 10000
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 200
-    autoRechargePause: true
-    autoRechargePauseTime: 12
+    autoRechargeRate: 30
   - type: AmmoCounter
 
 - type: entity
@@ -573,7 +571,7 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_antimatrifle
   - type: Gun
-    fireRate: 0.55
+    fireRate: 0.45
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -581,15 +579,15 @@
       path: /Audio/_Sunrise/Weapons/Guns/Snipers/Bauer127/bauer127_shot.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: CartridgeAntiMateriel
-    fireCost: 250
+    fireCost: 500
   - type: Battery
-    maxCharge: 1500
-    startingCharge: 1500
+    maxCharge: 4000
+    startingCharge: 4000
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 150
+    autoRechargeRate: 250
     autoRechargePause: true
-    autoRechargePauseTime: 15
+    autoRechargePauseTime: 20
   - type: AmmoCounter
 
 - type: entity
@@ -603,19 +601,19 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_autocannon
   - type: Gun
-    projectileSpeed: 20
+    projectileSpeed: 18
     minAngle: 1
     maxAngle: 20
     angleIncrease: 8
     angleDecay: 10
-    fireRate: 1.25
-    burstFireRate: 2.75
-    selectedMode: Burst
+    fireRate: 2.25
+    burstFireRate: 3.25
+    selectedMode: FullAuto
     availableModes:
     - Burst
     - FullAuto
     shotsPerBurst: 3
-    burstCooldown: 1.25
+    burstCooldown: 1.15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ship_duster.ogg
   - type: ProjectileBatteryAmmoProvider
@@ -626,7 +624,7 @@
     startingCharge: 1500
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 750
+    autoRechargeRate: 125
     autoRechargePause: true
     autoRechargePauseTime: 20
   - type: AmmoCounter

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -7,6 +7,7 @@
     proto: BulletGrenadeFragLight
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    scale: 0.85, 0.85
     layers:
     - state: frag
       map: ["enum.AmmoVisualLayers.Base"]

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -125,10 +125,13 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    maxIntensity: 5
-    intensitySlope: 3
-    totalIntensity: 60
+    maxIntensity: 2
+    intensitySlope: 1
+    totalIntensity: 4
     maxTileBreak: 0
+  - type: ProjectileGrenade
+    fillPrototype: PelletClusterLethal
+    capacity: 5
 
 # Shells that used for friendship and duster
 


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Мини чайна борга теперь осколочно-разрывная , малый урон и радиус от взрыва но создает 5 осколков
Подрезал скорострельность "Христова" для Борга до уровня христова в 0.45
Скоректировал зарядку и ёмкость заряда у Пулемета Тяжа по аналогии с L6 ROW борга
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
