### PR TITLE
Доступ ЦК боевому киборгу ОБР

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -212,6 +212,7 @@
     - Chapel
     - Hydroponics
     - Atmospherics
+    - CentralCommand
   - type: RandomMetadata
     nameSegments: [NamesBorg]
   - type: MovementSpeedModifier


### PR DESCRIPTION

## Кратное описание
Добавлен доступ Центрального командования для боевого киборга ОБР

## По какой причине
Боевой борг ОБР был без доступа к дверям шаттла ОБР/ЦК, из-за чего он не мог самостоятельно его покинуть или вернуться обратно.  


**Changelog**

:cl: danii17383

-tweak: Боевой борг ОБР теперь имеет доступ Центрального командования.
