### PR TITLE
Spider clown upgrade

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2778,7 +2778,7 @@
         melee:
           reagents:
             - ReagentId: Laughter
-              Quantity: "50"
+              Quantity: 50
     - type: MeleeChemicalInjector
       solution: melee
       transferAmount: 2

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2768,10 +2768,21 @@
       angle: 0
       animation: WeaponArcBite
       soundHit:
-        path: /Audio/Effects/bite.ogg
+        collection: ClownSpiderBiteSound #Sunrise edit
       damage:
         types:
           Piercing: 8
+    # Sunrise edit start
+    - type: SolutionContainerManager
+      solutions:
+        melee:
+          reagents:
+            - ReagentId: Laughter
+              Quantity: "50"
+    - type: MeleeChemicalInjector
+      solution: melee
+      transferAmount: 2
+    # Sunrise edit end
     - type: FootstepModifier
       footstepSoundCollection:
         collection: FootstepClownFast
@@ -3324,7 +3335,7 @@
     factions:
     - Syndicate
   - type: Access
-    tags: 
+    tags:
     - NuclearOperative
     - SyndicateAgent
   - type: MeleeWeapon

--- a/Resources/Prototypes/SoundCollections/bike_horn.yml
+++ b/Resources/Prototypes/SoundCollections/bike_horn.yml
@@ -32,3 +32,18 @@
   id: Parp
   files:
   - /Audio/Effects/Emotes/parp1.ogg
+
+# Sunrise edit start
+- type: soundCollection
+  id: ClownSpiderBiteSound
+  files:
+    - /Audio/Effects/bite.ogg
+    - /Audio/Effects/bite.ogg
+    - /Audio/Effects/bite.ogg
+    - /Audio/Items/bikehorn.ogg
+    - /Audio/Items/bikehorn.ogg
+    - /Audio/Items/bikehorn.ogg
+    - /Audio/Items/brokenbikehorn.ogg
+    - /Audio/Effects/Emotes/parp1.ogg
+
+# Sunrise edit end

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -212,7 +212,6 @@
     - Chapel
     - Hydroponics
     - Atmospherics
-    - CentralCommand
   - type: RandomMetadata
     nameSegments: [NamesBorg]
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -212,6 +212,7 @@
     - Chapel
     - Hydroponics
     - Atmospherics
+    - CentralCommand
   - type: RandomMetadata
     nameSegments: [NamesBorg]
   - type: MovementSpeedModifier


### PR DESCRIPTION

## Кратное описание

Клоун-паук теперь при укусе по предметам, а не по живым существам случайно издаёт один из четырёх звуков:  
- 37.5% шанс на укус,  
- 37.5% шанс на хонк,  
- 12.5% шанс на сломанный хонк,  
- 12.5% шанс на парп.  

Также при укусе вводит жертве 2 унции реагента "Смех", вызывающего приступы неконтролируемого смеха...

## По какой причине
Issue [#1548](https://github.com/space-sunrise/sunrise-station/issues/1548).

## Медиа(Видео/Скриншоты)

https://github.com/user-attachments/assets/ba9ae7e4-80f8-4afe-ad74-15cf7627fa80


**Changelog**

:cl: daniil7383
- add: Клоуны-пауки теперь при укусе могут издавать разные звуки и вводить жертве реагент Смех.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * У клоун-паука теперь при атаке воспроизводится случайный звук из новой коллекции, включающей укусы, клаксон и другие эффекты.
  * Клоун-паук при атаке вводит противнику химикат "Смех".

* **Исправления**
  * Незначительное исправление форматирования у сущности синдикат-кота (не влияет на игровой процесс).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->