### PR TITLE
Кадеты

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
@@ -85,3 +85,4 @@
   storage:
     back:
     - WeaponDisabler
+# sunrise end

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
@@ -44,24 +44,12 @@
   - !type:GroupLoadoutEffect
     proto: MasterCadet20h
 
-- type: startingGear
-  id: CadetWeaponACP14Box
-  storage:
-    back:
-    - ACP14Box
-
 - type: loadout
   id: CadetWeaponGlockBox
   startingGear: GlockBox
   effects:
   - !type:GroupLoadoutEffect
     proto: MasterCadet10h
-
-- type: startingGear
-  id: CadetWeaponGlockBox
-  storage:
-    back:
-    - GlockBox
 
 - type: loadout
   id: CadetWeaponEnergyGunPistolSecurity
@@ -70,19 +58,8 @@
   - !type:GroupLoadoutEffect
     proto: MasterCadet5h
 
-- type: startingGear
-  id: CadetWeaponEnergyGunPistolSecurity
-  storage:
-    back:
-    - WeaponEnergyGunPistolSecurity
-
 - type: loadout
   id: CadetWeaponDisabler
   startingGear: WeaponDisabler
 
-- type: startingGear
-  id: CadetWeaponDisabler
-  storage:
-    back:
-    - WeaponDisabler
 # sunrise end

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
@@ -8,3 +8,80 @@
   id: RedJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorRed
+
+# Sumrise_Start
+- type: loadoutEffectGroup
+  id: MasterCadet5h
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hrs
+
+- type: loadoutEffectGroup
+  id: MasterCadet10h
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 #10 hrs
+
+- type: loadoutEffectGroup
+  id: MasterCadet20h
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 #20 hrs
+
+- type: loadout
+  id: CadetWeaponACP14Box
+  startingGear: ACP14Box
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MasterCadet20h
+
+- type: startingGear
+  id: CadetWeaponACP14Box
+  storage:
+    back:
+    - ACP14Box
+
+- type: loadout
+  id: CadetWeaponGlockBox
+  startingGear: GlockBox
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MasterCadet10h
+
+- type: startingGear
+  id: CadetWeaponGlockBox
+  storage:
+    back:
+    - GlockBox
+
+- type: loadout
+  id: CadetWeaponEnergyGunPistolSecurity
+  startingGear: WeaponEnergyGunPistolSecurity
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MasterCadet5h
+
+- type: startingGear
+  id: CadetWeaponEnergyGunPistolSecurity
+  storage:
+    back:
+    - WeaponEnergyGunPistolSecurity
+
+- type: loadout
+  id: CadetWeaponDisabler
+  startingGear: WeaponDisabler
+
+- type: startingGear
+  id: CadetWeaponDisabler
+  storage:
+    back:
+    - WeaponDisabler

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -655,6 +655,7 @@
   - GroupSpeciesBreathToolSecurity
   - SecurityTrinkets  # Sunrise
   # Sunrise-start
+  - SunriseWeaponCadet
   - Bra
   - Pants
   - Socks

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -31,6 +31,7 @@
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
+    eyes: ClothingEyesHudSecurity
     belt: ClothingBeltSecurityFilled
     gloves: ClothingHandsGlovesColorGray
     pocket1: HyperLinkBookCorporateLaw # Sunrise-edit

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -31,7 +31,7 @@
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
-    eyes: ClothingEyesHudSecurity
+    eyes: ClothingEyesHudSecurity #Sunrise-edit
     belt: ClothingBeltSecurityFilled
     gloves: ClothingHandsGlovesColorGray
     pocket1: HyperLinkBookCorporateLaw # Sunrise-edit

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -31,6 +31,7 @@
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
+    belt: ClothingBeltSecurityFilled
     gloves: ClothingHandsGlovesColorGray
     pocket1: HyperLinkBookCorporateLaw # Sunrise-edit
   storage:

--- a/Resources/Prototypes/_Sunrise/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/loadout_groups.yml
@@ -227,6 +227,18 @@
   - WeaponDisabler
   - WeaponTaser
 
+# Security Cadet
+- type: loadoutGroup
+  id: SunriseWeaponCadet
+  name: loadout-group-security-gun
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - CadetWeaponGlockBox
+  - CadetWeaponACP14Box
+  - CadetWeaponEnergyGunPistolSecurity
+  - CadetWeaponDisabler
+
 # Security  Detective
 - type: loadoutGroup
   id: SunriseWeaponDetective


### PR DESCRIPTION
## Кратное описание
Вернул кадетам стартовое снаряжение

## По какой причине
Когда кадетов и другие роли новичков сделали бесконечными, у кадетов забрали всю снарягу что бы не спамили ею.

Кадеты более не бессконечные, но оставлять их без снаряжения нельзя.

## Медиа(Видео/Скриншоты)

**Changelog**

:cl: Kinar_7

- tweak: Nanotrasen повысил финасирование для снаряжения кадетов. Теперь они обладают стартовым вооружением



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлены новые варианты стартового оружия для должности Кадет службы безопасности, доступные по мере накопления времени работы в отделе (5, 10 и 20 часов).
  * Введена новая группа снаряжения SunriseWeaponCadet для выбора оружия кадетами.
  * К стартовому снаряжению кадета добавлен пояс снаряжения службы безопасности и HUD-очки.

* **Изменения в снаряжении**
  * Оружие и снаряжение теперь выдаются в зависимости от накопленного времени в отделе безопасности.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->