### PR TITLE
Фикс абуз Лунных ботинков 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -177,6 +177,8 @@
     - state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/moonboots.rsi
+    equipDelay: 0.75 #  Sunrise-Add
+    unequipDelay: 0.75  #  Sunrise-Add
   - type: AntiGravityClothing
   - type: StaticPrice
     price: 75


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Добавил короткий делей на одевание ботинков, теперь нельзя сочитая "Полицейский прыжок" и одновременное одевание на ходу пролететь большое растояние
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Для баланса вселенной, не весело(
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
https://discord.com/channels/1174575355370160190/1188705209615122523/1391497141234696292
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- fix: Исправлено веселье. Добавлены задержки при надевании и снятии лунных ботинок (0,75 секунды).
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Добавлены задержки при надевании и снятии лунных ботинок (0,75 секунды).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->