### PR TITLE
Малое усиление инженерных боргов

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -187,7 +187,7 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, BaseSecurityContraband]
+  parent: [ClothingEyesBase, BaseCommandContraband]
   id: ClothingEyesGlassesCommand
   name: administration glasses
   description: Upgraded sunglasses that provide flash immunity and show ID card status.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -187,7 +187,7 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseSecurityContraband] # Sunrise-Edit
   id: ClothingEyesGlassesCommand
   name: administration glasses
   description: Upgraded sunglasses that provide flash immunity and show ID card status.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -187,7 +187,7 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseSecurityContraband] # Sunrise-Edit
+  parent: [ClothingEyesBase, BaseSecurityContraband]
   id: ClothingEyesGlassesCommand
   name: administration glasses
   description: Upgraded sunglasses that provide flash immunity and show ID card status.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -226,6 +226,7 @@
       damageContainers:
       - Inorganic
       - Silicon
+      - Mech # Sunrise-edit
     - type: InteractionPopup
       interactSuccessString: petting-success-syndicate-cyborg
       interactFailureString: petting-failure-syndicate-cyborg

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -78,6 +78,11 @@
     params:
       volume: -15
   addComponents:
+  - type: ShowHealthBars
+    damageContainers:
+    - Inorganic
+    - Silicon
+    - Mech
   - type: InnateItem
     instantActions:
     - AtmosAlertsMonitor


### PR DESCRIPTION
## Кратное описание
Добавлена возможность инженерным боргам отслеживать состояние других боргов и мехов. 

## По какой причине
Удобство для инженерных боргов. 

## Медиа(Видео/Скриншоты)

![image](https://github.com/user-attachments/assets/a3f7e2c3-d3ba-4e2a-97df-39747a7d26ac)

**Changelog**

:cl: daniil7383
- add: Реконструкция модулей камеры у инженерного борга привела к возможности отслеживать состояние других боргов

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Новые возможности**
  * Для инженерного борга добавлено отображение полосы здоровья для типов повреждений "Неорганика", "Силикон" и "Мех".
  * Для синдикатного саботажного борга теперь отображается полоса здоровья для механических повреждений.

* **Изменения**
  * Изменён порядок наследования сущности командных очков для очков: теперь поддерживается отображение иконок безопасности и обновлена классификация контрабанды.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->