### PR TITLE
Поменял цвет в админ логах

### DIFF
--- a/Content.Client/_Sunrise/Administration/UI/CustomControls/SunriseAdminLogLabel.cs
+++ b/Content.Client/_Sunrise/Administration/UI/CustomControls/SunriseAdminLogLabel.cs
@@ -62,10 +62,10 @@ public sealed class SunriseAdminLogLabel : RichTextLabel
 
     private static string GetTypeSpecificColor(LogImpact type) => type switch
     {
-        LogImpact.Extreme => "magenta",
-        LogImpact.High => "red",
+        LogImpact.Extreme => "red",
+        LogImpact.High => "orange",
         LogImpact.Medium => "yellow",
-        LogImpact.Low => "cyan",
+        LogImpact.Low => "green",
 
         _ => "blue",
     };


### PR DESCRIPTION

## Кратное описание
Сменил цвет сложности действий в админ логах 
Низкая - Зеленое
Среднее - Жёлтое
Высокое - Оранжевое
Экстремальное - Красное
**Changelog**
Не нужно


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменение оформления**
  * Обновлены цвета для различных уровней важности логов: "Экстремальный" теперь отображается красным, "Высокий" — оранжевым, "Низкий" — зелёным.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->