### PR TITLE
Дуафтер залезания в сумку для фелинидов

### DIFF
--- a/Content.Server/_Sunrise/Felinid/FelinidSystem.cs
+++ b/Content.Server/_Sunrise/Felinid/FelinidSystem.cs
@@ -1,10 +1,7 @@
 using System.Linq;
-using Content.Server.Popups;
 using Content.Shared.Damage;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared._Sunrise.Felinid;
-using Content.Shared.Verbs;
-using Robust.Server.Containers;
 using Robust.Shared.Containers;
 
 namespace Content.Server._Sunrise.Felinid;
@@ -15,18 +12,12 @@ namespace Content.Server._Sunrise.Felinid;
 public sealed class FelinidSystem : SharedFelinidSystem
 {
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
-    [Dependency] private readonly ContainerSystem _containerSystem = default!;
-    [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly PopupSystem _popupSystem = default!;
-
-    public const string BaseStorageId = "storagebase";
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<FelinidComponent, MeleeHitEvent>(OnMeleeHit);
-        SubscribeLocalEvent<FelinidContainerComponent, GetVerbsEvent<AlternativeVerb>>(AddInsertAltVerb);
         SubscribeLocalEvent<FelinidContainerComponent, EntRemovedFromContainerMessage>(OnEntityRemoved);
     }
 
@@ -42,35 +33,6 @@ public sealed class FelinidSystem : SharedFelinidSystem
 
         felinidComponent.InContainer = false;
         Dirty(args.Entity, felinidComponent);
-    }
-
-    private void AddInsertAltVerb(EntityUid uid, FelinidContainerComponent component, GetVerbsEvent<AlternativeVerb> args)
-    {
-        if (!args.CanInteract || !args.CanAccess)
-            return;
-
-        if (!TryComp<FelinidComponent>(args.User, out var felinidComponent))
-            return;
-
-        AlternativeVerb verb = new()
-        {
-            Act = () =>
-            {
-                if (!_container.TryGetContainer(uid, BaseStorageId, out var storageContainer))
-                    return;
-
-                if (_containerSystem.Insert(args.User, storageContainer))
-                {
-                    felinidComponent.InContainer = true;
-                    Dirty(args.User, felinidComponent);
-                }
-                else
-                    _popupSystem.PopupEntity("Не удалось", args.User, args.User);
-            },
-            Text = "Залезть внутрь",
-            Priority = 2
-        };
-        args.Verbs.Add(verb);
     }
 
     private void OnMeleeHit(EntityUid uid, FelinidComponent component, MeleeHitEvent args)

--- a/Content.Shared/_Sunrise/Carrying/SharedCarryingSystem.cs
+++ b/Content.Shared/_Sunrise/Carrying/SharedCarryingSystem.cs
@@ -146,17 +146,17 @@ public sealed class SharedCarryingSystem : EntitySystem
         if (mod != 0)
             length /= mod;
 
-        if (length >= TimeSpan.FromSeconds(MaxCarryTime))
-        {
-            _popupSystem.PopupPredicted(Loc.GetString("carry-too-heavy"), carried, carrier, PopupType.SmallCaution);
-            return;
-        }
-
         if (!HasComp<KnockedDownComponent>(carried))
             length *= 2f;
 
         if (TryComp<MobStateComponent>(carried, out var mobState) && mobState.CurrentState != MobState.Alive)
             length /= 2f;
+
+        if (length >= TimeSpan.FromSeconds(MaxCarryTime))
+        {
+            _popupSystem.PopupPredicted(Loc.GetString("carry-too-heavy"), carried, carrier, PopupType.SmallCaution);
+            return;
+        }
 
         var ev = new CarryDoAfterEvent();
         var args = new DoAfterArgs(EntityManager, carrier, length, ev, carried, target: carried)

--- a/Content.Shared/_Sunrise/Felinid/FelinidPickupDoAfterEvent.cs
+++ b/Content.Shared/_Sunrise/Felinid/FelinidPickupDoAfterEvent.cs
@@ -1,9 +1,0 @@
-using Content.Shared.DoAfter;
-using Robust.Shared.Serialization;
-
-namespace Content.Shared._Sunrise.Felinid;
-
-[Serializable, NetSerializable]
-public sealed partial class FelinidPickupDoAfterEvent : SimpleDoAfterEvent
-{
-}

--- a/Resources/Locale/ru-RU/_strings/_sunrise/felinid/felinid.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/felinid/felinid.ftl
@@ -1,0 +1,1 @@
+unsuccessfully-insert = Не удалось залезть

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/felinid.yml
@@ -409,7 +409,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 100
+        density: 40
         restitution: 0.0
         mask:
         - MobMask


### PR DESCRIPTION
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: kanopus7
- add: Добавлена задержка на залезание в сумку для фелинидов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена альтернатива действия для помещения Felinid в контейнер с помощью специального действия с задержкой.
  * Добавлено сообщение об ошибке при неудачной попытке поместить Felinid в контейнер (локализовано на русском языке).

* **Исправления**
  * Улучшена логика подбора Felinid: время задержки теперь зависит от состояния цели (жив или мёртв).
  * Исправлены проверки наличия свободной руки при подборе Felinid.
  * Скорректирована проверка максимального времени переноски с учётом состояния переносимого объекта.

* **Локализация**
  * Добавлено новое сообщение для неудачной попытки залезть в контейнер.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->