### PR TITLE
отключение ттс рации у гостов

### DIFF
--- a/Content.Client/Options/UI/Tabs/ExtraTab.xaml
+++ b/Content.Client/Options/UI/Tabs/ExtraTab.xaml
@@ -25,6 +25,7 @@
                 <Label Text="{Loc 'ui-options-sunrise-general-audio'}" StyleClasses="LabelKeyText"/>
                 <CheckBox Name="TtsClientCheckBox" Text="{Loc 'ui-options-tts-enabled'}" />
                 <CheckBox Name="TtsClientCheckBoxQueue" Text="{Loc 'ui-options-tts-queue'}" />
+                <CheckBox Name="TtsRadioGhostCheckBox" Text="{Loc 'ui-options-tts-radio-ghost-enabled'}" />
                 <ui:OptionSlider Name="SliderTts" Title="{Loc 'ui-options-tts-volume'}" />
                 <ui:OptionSlider Name="SliderTtsRadio" Title="{Loc 'ui-options-tts-radio-volume'}" />
                 <ui:OptionSlider Name="SliderTtsAnnounce" Title="{Loc 'ui-options-tts-announce-volume'}" />

--- a/Content.Client/Options/UI/Tabs/ExtraTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/ExtraTab.xaml.cs
@@ -39,6 +39,7 @@ public sealed partial class ExtraTab : Control
 
         Control.AddOptionCheckBox(SunriseCCVars.TTSClientEnabled, TtsClientCheckBox);
         Control.AddOptionCheckBox(SunriseCCVars.TTSClientQueueEnabled, TtsClientCheckBoxQueue);
+        Control.AddOptionCheckBox(SunriseCCVars.TTSRadioGhostEnabled, TtsRadioGhostCheckBox);
         Control.AddOptionCheckBox(SunriseCCVars.TapePlayerClientEnabled, TapePlayerClientCheckBox);
         Control.AddOptionCheckBox(SunriseCCVars.JumpSoundDisable, JumpSoundDisableCheckBox);
         Control.AddOptionCheckBox(SunriseCCVars.VoteMusicDisable, VoteMusicDisableCheckBox);

--- a/Content.Client/_Sunrise/TTS/TTSSystem.cs
+++ b/Content.Client/_Sunrise/TTS/TTSSystem.cs
@@ -1,7 +1,9 @@
 ﻿using Content.Shared._Sunrise.SunriseCCVars;
 using Content.Shared._Sunrise.TTS;
 using Content.Shared.CCVar;
+using Content.Shared.Ghost;
 using Robust.Client.Audio;
+using Robust.Client.Player;
 using Robust.Client.ResourceManagement;
 using Robust.Shared;
 using Robust.Shared.Audio;
@@ -25,6 +27,7 @@ public sealed class TTSSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _sharedAudio = default!;
     [Dependency] private readonly IResourceCache _resourceCache = default!;
     [Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
 
     private ISawmill _sawmill = default!;
     private static readonly MemoryContentRoot ContentRoot = new();
@@ -35,6 +38,7 @@ public sealed class TTSSystem : EntitySystem
     private int _fileIdx;
     private float _volumeAnnounce;
     private bool _isQueueEnabled;
+    private bool _ghostRadioEnabled;
     private readonly Queue<QueuedTts> _ttsQueue = new();
     private (EntityUid Entity, AudioComponent Component)? _currentPlaying;
     private static readonly AudioResource EmptyAudioResource = new();
@@ -62,6 +66,7 @@ public sealed class TTSSystem : EntitySystem
         _cfg.OnValueChanged(SunriseCCVars.TTSAnnounceVolume, OnTtsAnnounceVolumeChanged, true);
         _cfg.OnValueChanged(SunriseCCVars.TTSClientEnabled, OnTtsClientOptionChanged, true);
         _cfg.OnValueChanged(SunriseCCVars.TTSClientQueueEnabled, OnTTSQueueOptionChanged, true);
+        _cfg.OnValueChanged(SunriseCCVars.TTSRadioGhostEnabled, OnTtsRadioGhostChanged, true);
         SubscribeNetworkEvent<PlayTTSEvent>(OnPlayTTS);
         SubscribeNetworkEvent<AnnounceTtsEvent>(OnAnnounceTTSPlay);
     }
@@ -74,6 +79,7 @@ public sealed class TTSSystem : EntitySystem
         _cfg.UnsubValueChanged(SunriseCCVars.TTSAnnounceVolume, OnTtsAnnounceVolumeChanged);
         _cfg.UnsubValueChanged(SunriseCCVars.TTSClientEnabled, OnTtsClientOptionChanged);
         _cfg.UnsubValueChanged(SunriseCCVars.TTSClientQueueEnabled, OnTTSQueueOptionChanged);
+        _cfg.UnsubValueChanged(SunriseCCVars.TTSRadioGhostEnabled, OnTtsRadioGhostChanged);
 
         ContentRoot.Clear();
         _currentPlaying = null;
@@ -107,6 +113,11 @@ public sealed class TTSSystem : EntitySystem
     private void OnTtsClientOptionChanged(bool option)
     {
         RaiseNetworkEvent(new ClientOptionTTSEvent(option));
+    }
+
+    private void OnTtsRadioGhostChanged(bool option)
+    {
+        _ghostRadioEnabled = option;
     }
 
     private void OnAnnounceTTSPlay(AnnounceTtsEvent ev)
@@ -158,12 +169,19 @@ public sealed class TTSSystem : EntitySystem
         if (volume == 0)
             return;
 
-        if (ev.IsRadio && _isQueueEnabled)
+        if (ev.IsRadio)
         {
-            var entry = new QueuedTts(ev.Data, TtsType.Radio);
+            var localEntity = _playerManager.LocalEntity;
+            if(!_ghostRadioEnabled && localEntity.HasValue && HasComp<GhostComponent>(localEntity.Value))
+                return;
 
-            _ttsQueue.Enqueue(entry);
-            return;
+            if (_isQueueEnabled)
+            {
+                var entry = new QueuedTts(ev.Data, TtsType.Radio);
+
+                _ttsQueue.Enqueue(entry);
+                return;
+            }
         }
 
         volume = SharedAudioSystem.GainToVolume(volume * ev.VolumeModifier);

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
@@ -39,6 +39,9 @@ public sealed partial class SunriseCCVars : CVars
     public static readonly CVarDef<bool> TTSClientEnabled =
         CVarDef.Create("tts.client_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+    public static readonly CVarDef<bool> TTSRadioGhostEnabled =
+        CVarDef.Create("tts.radio_ghost_enabled", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
     /// <summary>
     /// Option to disable TTS queue in radio for client
     /// </summary>

--- a/Resources/Locale/ru-RU/_strings/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/ru-RU/_strings/escape-menu/ui/options-menu.ftl
@@ -41,6 +41,7 @@ ui-options-admin-sounds = Музыка админов
 ui-options-bwoink-sound = Воспроизводить звук уведомления АХелп
 ui-options-tts-enabled = ТТС интеграция
 ui-options-tts-queue = Использовать очередь для TTS рации?
+ui-options-tts-radio-ghost-enabled = ТТС рации в призраке
 ui-options-volume-label = Громкость
 
 ## Graphics menu


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
добавляет настройку, при отключении которой ттс рации у гостов не воспроизводится
по умолчанию отключена

## По какой причине
да

**Changelog**
:cl: Ligyb
- add: Добавлена настройка, позволяющая отключать ттс рации для призраков.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Добавлена опция в настройках аудио для включения или отключения воспроизведения радио TTS для игроков-призраков.
  * Добавлен новый чекбокс в меню настроек для управления этой функцией.
  * Добавлен перевод новой опции на русский язык.

* **Исправления**
  * Радио TTS теперь корректно отключается для призраков, если опция выключена.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->