### PR TITLE
Фикс скафандра хамелеона

### DIFF
--- a/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
@@ -79,8 +79,8 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
         // make sure that it is valid change
         if (string.IsNullOrEmpty(protoId) || !_proto.TryIndex(protoId, out EntityPrototype? proto))
             return;
-        if (!IsValidTarget(proto, component.Slot, component.RequireTag))
-            return;
+        //if (!IsValidTarget(proto, component.Slot, component.RequireTag)) //Sunrise-Edit
+            //return; //Sunrise-Edit
         component.Default = protoId;
 
         UpdateIdentityBlocker(uid, component, proto);

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
@@ -14,6 +14,7 @@
     - type: ChameleonClothing
       slot: [outerClothing]
       default: ClothingOuterVest
+      requireTag: Vest # Sunrise-Edit
     - type: UserInterface
       interfaces:
         enum.ChameleonUiKey.Key:

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -479,3 +479,5 @@
           Heat: 0.4
           Radiation: 0.5
           Caustic: 0.5
+    - type: ToggleableClothing
+      clothingPrototype: ClothingHeadHelmetEVA


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Фикс проблемы оффов связанной с нерабочей фильтрацией по тагам для хамелеоновой одежды
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
https://github.com/space-sunrise/sunrise-station/issues/2407 Когда то давно я решил эту проблему, забил, так как по хорошему надо было другую одежду доделывать, а потом увидел что так и не решили проблему.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="446" height="465" alt="image" src="https://github.com/user-attachments/assets/9a6f5a57-47c3-430c-9796-86f5e5d99416" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Для хамелеонового скафандра добавлена возможность переключения шлема EVA.
  * Компонент хамелеоновой одежды теперь требует наличие тега "Vest" для некоторых предметов.

* **Изменения в поведении**
  * Сняты ограничения на выбор прототипа для хамелеоновой одежды, теперь можно выбирать больше вариантов независимо от соответствия слоту или тегу.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->