### PR TITLE
Добавлено требование по времени за посетителей

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/visitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/visitor.yml
@@ -3,6 +3,9 @@
   name: job-name-visitor
   description: job-description-visitor
   playTimeTracker: JobVisitor
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 36000 #10 hr # Sunrise-RoleTime
   canBeAntag: false
   icon: JobIconVisitor
   setPreference: false


### PR DESCRIPTION
Набегаторы брали посетителей с шаттлами и таранили станцию создавая массивный грифон

CL не нужен наверное


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Для получения доступа к роли "Посетитель" теперь требуется минимум 10 часов общего игрового времени.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->