### PR TITLE
Удалены доступы в техи для пилота и инструктора СБ

### DIFF
--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/fun/toys.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/fun/toys.ftl
@@ -169,4 +169,4 @@ ent-PlushieTimofeyTatarchuk = Плюшевый Тимофей Татарчук
 ent-PlushieSansaMontanelli = Плюшевая Санса Монтанелли
     .desc = Маленький бюрократ...Она уже пишет на вас заявление!
 ent-PlushieKalium = Калий Фон Дез
-    .desc = Просто добавте воды!
+    .desc = Просто добавьте воды!

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Security/security_pilot.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Security/security_pilot.yml
@@ -15,7 +15,6 @@
   access:
   - Security
   - Brig
-  - Maintenance
   - Service
   - External
   special:

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Security/senior_officer.yml
@@ -24,7 +24,6 @@
   access:
   - Security
   - Brig
-  - Maintenance
   - Service
   - External
   special:


### PR DESCRIPTION
## Кратное описание
Урезал доступы в техпомещения пилоту и инструктору СБ

## По какой причине
СБ не должны иметь доступы в техи. Они оставлены лишь бригмедику и детективу для их работы

**Changelog**
Были удалены доступы пилоту и инструктору СБ в техпомещения.

:cl: Gpxgji
- tweak: Вырезан доступ в техи пилоту и инструктору СБ
