### PR TITLE
Небольшие изменения в расах

### DIFF
--- a/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
@@ -10,11 +10,9 @@
 - type: damageModifierSet
   id: Swine
   coefficients:
-    Blunt: 0.6
-    Slash: 0.75
-    Piercing: 0.75
+    Blunt: 0.8
+    Slash: 0.8
     Cold: 0.8
-    Heat: 0.8
 
 - type: damageModifierSet
   id: Predator

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/demon.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/demon.yml
@@ -5,9 +5,7 @@
   id: BaseMobDemon
   abstract: true
   components:
-  # SUNRISE EDIT
   - type: Interactions
-  # SUNRISE EDIT
   - type: Absorbable
   - type: HumanoidAppearance
     species: Demon

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
@@ -5,9 +5,7 @@
   name: Urist McXeno
   abstract: true
   components:
-  # SUNRISE EDIT
   - type: Interactions
-  # SUNRISE EDIT
   - type: Absorbable
   - type: Respirator
     damage:

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/predator.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/predator.yml
@@ -5,9 +5,7 @@
   name: Urist McPredator
   abstract: true
   components:
-  # SUNRISE EDIT
   - type: Interactions
-  # SUNRISE EDIT
   - type: Absorbable
   - type: Hunger
   - type: Icon # It will not have an icon in the adminspawn menu without this. Body parts seem fine for whatever reason.

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/swine.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/swine.yml
@@ -4,9 +4,7 @@
   id: BaseMobSwine
   abstract: true
   components:
-  # SUNRISE EDIT
   - type: Interactions
-  # SUNRISE EDIT
   - type: Absorbable
   - type: HumanoidAppearance
     species: Swine

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/tajaran.yml
@@ -3,9 +3,7 @@
   id: BaseMobTajaran
   abstract: true
   components:
-  # SUNRISE EDIT
   - type: Interactions
-  # SUNRISE EDIT
   - type: Absorbable
   - type: HumanoidAppearance
     species: Tajaran

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/vulpkanin.yml
@@ -5,9 +5,7 @@
   id: BaseMobVulpkanin
   abstract: true
   components:
-  # SUNRISE EDIT
   - type: Interactions
-  # SUNRISE EDIT
   - type: Absorbable
   - type: Speech
     speechVerb: Vulpkanin


### PR DESCRIPTION
Понизил резисты свиньям (С одобрения сплика), убрал лишние эдиты
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: kanopus7
- tweak: Теперь у свинолюдей всего 20% резиста к Blunt, Slash и Heat урону. Остальные резисты возвращены к дефолтному значению