### PR TITLE
Ребаланс руки-клинка генокрада

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/changeling_armblade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/changeling_armblade.yml
@@ -12,7 +12,7 @@
     attackRate: 0.75
     damage:
       types:
-        Slash: 10
+        Slash: 20
         Piercing: 10
         Structural: 10
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/changeling_armblade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/changeling_armblade.yml
@@ -14,7 +14,7 @@
       types:
         Slash: 20
         Piercing: 10
-        Structural: 10
+        Structural: 20
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Item


### PR DESCRIPTION
## Кратное описание
Повысил урон порезами от руки-клинка генокрада с 10 до 20. Структурный урон повышен с 10 до 20.

## По какой причине
Рука-клинок генокрада сейчас по сути мусор и не юзабельна, из за ее кд на удары и низкого урона

**Changelog**

:cl: Gpxgji
- tweak: Повышен урон от руки-клинка генокрада.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения баланса**
  * Урон от типов "Slash" и "Structural" для оружия ArmBladeChangeling увеличен с 10 до 20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->