### PR TITLE
Дебафф побега

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -218,7 +218,7 @@
   description: Randomly teleports you within a large distance.
   components:
   - type: LimitedCharges
-    maxCharges: 1
+    maxCharges: 1 # Sunrise-edit
   # Sunrise-Start
   - type: AutoRecharge
     rechargeDuration: 360

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -218,7 +218,7 @@
   description: Randomly teleports you within a large distance.
   components:
   - type: LimitedCharges
-    maxCharges: 2
+    maxCharges: 1
   # Sunrise-Start
   - type: AutoRecharge
     rechargeDuration: 360


### PR DESCRIPTION
Делаем имплант чуть более скиллозависимым

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: kanopus7
- tweak: Заряды импланта побег снижены до 1 единицы.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения в функциональности**
  * Максимальное количество зарядов для действия "Активировать скрам-имплант" уменьшено с 2 до 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->