### PR TITLE
Bugfixes

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -7,7 +7,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Power;
 using Content.Shared.Wires;
 using Robust.Shared.Player;
-
+using Content.Shared.Silicons.StationAi;
 namespace Content.Server.Doors.Systems;
 
 public sealed class AirlockSystem : SharedAirlockSystem
@@ -62,6 +62,11 @@ public sealed class AirlockSystem : SharedAirlockSystem
             panel.Open &&
             TryComp<ActorComponent>(args.User, out var actor))
         {
+            //Sunrise-start
+            if (HasComp<StationAiHeldComponent>(args.User))
+                return;
+            //Sunrise-end
+
             if (TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
                 !wiresPanelSecurity.WiresAccessible)
                 return;

--- a/Content.Server/VoiceMask/VoiceMaskSystem.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.cs
@@ -38,7 +38,7 @@ public sealed partial class VoiceMaskSystem : EntitySystem
 
         InitializeTTS(); // Sunrise-TTS
 
-        //Subs.CVar(_cfgManager, CCVars.MaxNameLength, value => _maxNameLength = value, true);
+        Subs.CVar(_cfgManager, CCVars.MaxNameLength, value => _maxNameLength = value, true);
     }
 
     private void OnTransformSpeakerName(Entity<VoiceMaskComponent> entity, ref InventoryRelayedEvent<TransformSpeakerNameEvent> args)

--- a/Resources/Locale/ru-RU/_strings/_sunrise/animals/dogs/dogs.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/animals/dogs/dogs.ftl
@@ -1,0 +1,5 @@
+ghost-role-information-pibble-vent-name = Вентибуль
+ghost-role-information-pibble-vent-description = Какая-то помесь питбуля... или, может быть, это следующий этап эволюции питбуля?
+
+ghost-role-information-pibble-name = Питбуль
+ghost-role-information-pibble-description = Собака-няня. Или помесь с лабрадором, зависит от того, кого спросить.

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -24,7 +24,7 @@
     EnergyShotgunStealObjective: 0.5
     # Sunrise-Start
     PlutoniumCoreStealObjective: 0.5
-    MultiphaseEnergygunStealObjective: 1
+    #MultiphaseEnergygunStealObjective: 1 # Sunrise-Edit: ОСЩ больше не появляется на станции
     CMOAdvancedDefibrillatorStealObjective: 1
     StealSupermatterSliverObjective: 1
     HandheldFaxStealObjective: 1

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -32,9 +32,10 @@
   name: Fix the space-time paradox.
   description: Replace your original to fix the paradox. Remember, your mission is to blend in, do not kill anyone else unless you have to!
   components:
+  #Sunrise-start
+  - type: TargetObjective
+    title: objective-condition-kill-head-title # kill <name>, <job>
   - type: PickSpecificPerson
   - type: KillPersonCondition
     requireDead: true
-  - type: TargetObjective
-    title: objective-condition-kill-head-title # kill <name>, <job>
-
+  #Sunrise-end

--- a/Resources/Prototypes/_Sunrise/AssaultOps/roundstart.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/roundstart.yml
@@ -32,6 +32,10 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: RandomMetadata
+        nameSegments:
+        - NamesSyndicateNormal
+        nameFormat: name-format-nukie-commander
       mindRoles:
       - MindRoleAssaultCommander
     - prefRoles: [ AssaultOperative ]
@@ -47,5 +51,9 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: RandomMetadata
+        nameSegments:
+        - NamesSyndicateNormal
+        nameFormat: name-format-nukie-operator
       mindRoles:
       - MindRoleAssaultOperative

--- a/Resources/Prototypes/_Sunrise/AssaultOps/roundstart.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/roundstart.yml
@@ -34,8 +34,9 @@
         - Syndicate
       - type: RandomMetadata
         nameSegments:
-        - NamesSyndicateNormal
-        nameFormat: name-format-nukie-commander
+        - NamesFirst
+        - NamesLast
+        nameFormat: name-format-standard
       mindRoles:
       - MindRoleAssaultCommander
     - prefRoles: [ AssaultOperative ]
@@ -53,7 +54,8 @@
         - Syndicate
       - type: RandomMetadata
         nameSegments:
-        - NamesSyndicateNormal
-        nameFormat: name-format-nukie-operator
+        - NamesFirst
+        - NamesLast
+        nameFormat: name-format-standard
       mindRoles:
       - MindRoleAssaultOperative


### PR DESCRIPTION
## Кратное описание
Исправлены мелкие баги и недоработки:
1. Исправлена голосовая маска теперь можно менять имя и акцент.
2. Диверсанты больше не появляются с именами "МакЧеловек". (Теперь у них будут случайные имена. К примеру: Айли Гренс)
3. ИИ теперь может взаимодействовать с дверьми с открытой панелью.
4. У агентов больше нет цели на мультифазный энергетический карабин. (Офицера "Синего щита" убрали а про особый предмет забыли)
5. В ролях призрака корректно отображаются питбуль и вентибуль.
6. Фикс цели у парадокс-клона (Офы сделали неправильно: сначала шла проверка смерти, потом выбор цели, и только в конце создание цели. Из-за этого система не знала, кого отслеживать, и цель считалась выполненной сразу. Я исправил порядок. К сожалению протестить на локалке невозможно. Должно работать)

**Changelog**

:cl: daniil7383
- fix: Исправлена голосовая маска, теперь можно менять имя и акцент
- fix: Исправлены имена диверсантов
- fix: ИИ теперь может взаимодействовать со шлюзами с открытой панелью
- fix: Более нет цели на мультифазный энергетический карабин у агентов
- fix: Исправлено отображение питбуля и вентибуля в ролях призрака 
- fix: Исправлена цель у падакс-клонов

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлены новые русскоязычные описания и имена для ролей собак, включая питбуля и его вариант "vent".
  * Для NPC-фракций "Штурмовой командир" и "Штурмовой оперативник" теперь используются случайно генерируемые имена.

* **Исправления**
  * Игроки с определённым статусом больше не могут взаимодействовать с панелью проводов шлюзов.
  * Исправлена подписка на изменение максимальной длины имени для маскировки голоса.

* **Изменения**
  * Отключено получение задания на кражу многофазного энергооружия для предателей, так как оно больше не появляется на станции.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->