### PR TITLE
Игроки теперь ничего не видят, будучи в трубе

### DIFF
--- a/Content.Server/_Sunrise/Misc/BlindInDisposals/BlindInDisposalsSystem.cs
+++ b/Content.Server/_Sunrise/Misc/BlindInDisposals/BlindInDisposalsSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Disposal.Unit;
 using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
 
 namespace Content.Server._Sunrise.Misc.BlindInDisposals;
 
@@ -9,27 +10,40 @@ namespace Content.Server._Sunrise.Misc.BlindInDisposals;
 /// </summary>
 public sealed class BlindInDisposalsSystem : EntitySystem
 {
+    [Dependency] private readonly BlindableSystem _blindable = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<BeingDisposedComponent, ComponentStartup>(OnStartup);
-        SubscribeLocalEvent<BeingDisposedComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<BeingDisposedComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<BeingDisposedComponent, CanSeeAttemptEvent>(OnCanSee);
     }
 
     private void OnStartup(Entity<BeingDisposedComponent> ent, ref ComponentStartup args)
     {
+        // Это здесь, так как АПИ тела вызывает NRE при отсутствии глаз у выбранного ентити. Крутая система
+        // TODO: Портировать фикс NRE с фаера
         if (!HasComp<BlindableComponent>(ent))
             return;
 
-        EnsureComp<TemporaryBlindnessComponent>(ent);
+        _blindable.UpdateIsBlind(ent.Owner);
     }
 
-    private void OnShutdown(Entity<BeingDisposedComponent> ent, ref ComponentShutdown args)
+    private void OnRemove(Entity<BeingDisposedComponent> ent, ref ComponentRemove args)
     {
         if (!HasComp<BlindableComponent>(ent))
             return;
 
-        RemComp<TemporaryBlindnessComponent>(ent);
+        _blindable.UpdateIsBlind(ent.Owner);
+    }
+
+    private void OnCanSee(Entity<BeingDisposedComponent> ent, ref CanSeeAttemptEvent args)
+    {
+        if (!HasComp<BlindableComponent>(ent))
+            return;
+
+        args.Cancel();
     }
 }

--- a/Content.Server/_Sunrise/Misc/BlindInDisposals/BlindInDisposalsSystem.cs
+++ b/Content.Server/_Sunrise/Misc/BlindInDisposals/BlindInDisposalsSystem.cs
@@ -1,0 +1,35 @@
+﻿using Content.Server.Disposal.Unit;
+using Content.Shared.Eye.Blinding.Components;
+
+namespace Content.Server._Sunrise.Misc.BlindInDisposals;
+
+/// <summary>
+/// Простая система, делающая персонажа слепым, пока он находится в трубах.
+/// Из труб не должно быть видно реальный мир!!
+/// </summary>
+public sealed class BlindInDisposalsSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BeingDisposedComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<BeingDisposedComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private void OnStartup(Entity<BeingDisposedComponent> ent, ref ComponentStartup args)
+    {
+        if (!HasComp<BlindableComponent>(ent))
+            return;
+
+        EnsureComp<TemporaryBlindnessComponent>(ent);
+    }
+
+    private void OnShutdown(Entity<BeingDisposedComponent> ent, ref ComponentShutdown args)
+    {
+        if (!HasComp<BlindableComponent>(ent))
+            return;
+
+        RemComp<TemporaryBlindnessComponent>(ent);
+    }
+}

--- a/Content.Server/_Sunrise/Misc/BlindInDisposals/BlindInDisposalsSystem.cs
+++ b/Content.Server/_Sunrise/Misc/BlindInDisposals/BlindInDisposalsSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Server.Disposal.Unit;
+using Content.Shared._Sunrise.VentCraw;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Humanoid;
 
 namespace Content.Server._Sunrise.Misc.BlindInDisposals;
 
@@ -44,6 +46,20 @@ public sealed class BlindInDisposalsSystem : EntitySystem
         if (!HasComp<BlindableComponent>(ent))
             return;
 
+        if (CanSeeInTube(ent))
+            return;
+
         args.Cancel();
+    }
+
+    private bool CanSeeInTube(EntityUid uid)
+    {
+        if (!HasComp<VentCrawlerComponent>(uid))
+            return false;
+
+        if (HasComp<HumanoidAppearanceComponent>(uid))
+            return false;
+
+        return true;
     }
 }


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Какой-то гений на фаере добавил в правило о метаинфе, что нельзя использовать инфу, полученную будучи в трубе.
Сошлись, что это стоит добавить механом. Добавил

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: ThereDrD
- tweak: Теперь находясь в трубе гуманоиды становятся слепыми. Не распространяется на фауну.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Персонажи теперь становятся слепыми, находясь внутри мусоропроводов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->