### PR TITLE
Revert "Истощение"

### DIFF
--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -129,7 +129,7 @@ public sealed class HealingSystem : EntitySystem
         var healingDict = healing.Damage.DamageDict;
         foreach (var type in healingDict)
         {
-            if (damageableDict.TryGetValue(type.Key, out var damageValue) && damageValue.Value > 0 && type.Key != "Mangleness") //Sunrise-edit: fix server crashes
+            if (damageableDict.TryGetValue(type.Key, out var damageValue) && damageValue.Value > 0) //Sunrise-edit: fix server crashes
             {
                 return true;
             }

--- a/Resources/Locale/en-US/_strings/damage/damage-types.ftl
+++ b/Resources/Locale/en-US/_strings/damage/damage-types.ftl
@@ -12,4 +12,3 @@ damage-type-shock = Shock
 damage-type-slash = Slash
 damage-type-structural = Structural
 damage-type-holy = Holy
-damage-type-mangleness = Mangleness

--- a/Resources/Locale/ru-RU/_strings/damage/damage-types.ftl
+++ b/Resources/Locale/ru-RU/_strings/damage/damage-types.ftl
@@ -12,4 +12,3 @@ damage-type-shock = Электрические
 damage-type-slash = Порезы
 damage-type-structural = Структурные
 damage-type-holy = Святой
-damage-type-mangleness = Истощение

--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -33,8 +33,6 @@
     - Shock
     - Caustic
     - Structural
-    - Mangleness # Sunrise-Edit
-
 
 - type: damageContainer
   id: Shield

--- a/Resources/Prototypes/Damage/groups.yml
+++ b/Resources/Prototypes/Damage/groups.yml
@@ -40,7 +40,6 @@
   name: damage-group-genetic
   damageTypes:
     - Cellular
-    - Mangleness # Sunrise-Edit
 
 # Metaphysical damage types should be used very sparingly, and likely not affect normal crew entities.
 # Revenants and other ghost-like/demonic creatures are more fitting. Healing should never be available via medicine.

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -265,7 +265,6 @@
     Shock: 0.0
     Slash: 0.25
     Structural: 0.0
-    Mangleness: 0.0 # Sunrise-Edit
 
 - type: damageModifierSet
   id: SlimePet # Very survivable slimes

--- a/Resources/Prototypes/Damage/types.yml
+++ b/Resources/Prototypes/Damage/types.yml
@@ -92,11 +92,3 @@
   armorCoefficientPrice: 1
   armorFlatPrice: 1
 
-#Sunrise-Start
-- type: damageType
-  id: Mangleness
-  name: damage-type-mangleness
-  armorCoefficientPrice: 1
-  armorFlatPrice: 1
-#Sunrise-End
-

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -113,7 +113,6 @@
         Piercing: -15
         Caustic: -15
         Structural: -15
-        Mangleness: 5 #SUNRISE-EDIT
     allowSelfRepair: false
   # Sunrise-End
   - type: BorgChassis

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -284,7 +284,6 @@
     damage:
       types:
         Heat: -0.07
-        Mangleness: -0.01 #SUNRISE-EDIT
       groups:
         Brute: -0.07
   - type: Fingerprint

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -102,7 +102,6 @@
       types:
         Slash: -0.5
         Piercing: -0.5
-        Mangleness: 0.5 #SUNRISE-EDIT
     bloodlossModifier: -4
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -101,7 +101,6 @@
         Piercing: -15
         Caustic: -15
         Structural: -15
-        Mangleness: 7.5 # Sunrise-Edit
   - type: UserInterface
     interfaces:
       enum.MechUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -36,8 +36,6 @@
         Cold: -5
         Shock: -5
         Caustic: -1.5
-        Mangleness: 0.2 #SUNRISE-EDIT
-
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
       params:
@@ -95,7 +93,6 @@
         Cold: -10
         Shock: -10
         Caustic: -10
-        Mangleness: 1.2 #SUNRISE-EDIT
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
       params:
@@ -148,8 +145,6 @@
     damageContainers:
       - Biological
     damage:
-      types: #SUNRISE-EDIT
-        Mangleness: 0.3 #SUNRISE-EDIT
       groups:
         Brute: -15 # 5 for each type in the group
     healingBeginSound:
@@ -205,8 +200,6 @@
     damageContainers:
       - Biological
     damage:
-      types: #SUNRISE-EDIT
-        Mangleness: 1.2 #SUNRISE-EDIT
       groups:
         Brute: -30 # 10 for each type in the group
     bloodlossModifier: -10 # a suture should stop ongoing bleeding
@@ -264,7 +257,6 @@
     damage:
       types:
         Bloodloss: -0.5 #lowers bloodloss damage
-        Mangleness: 0.1 #SUNRISE-EDIT
     ModifyBloodLevel: 15 #restores about 5% blood per use on standard humanoids.
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
@@ -359,7 +351,6 @@
       types:
         Slash: -5
         Piercing: -10
-        Mangleness: 0.5 #SUNRISE-EDIT
     bloodlossModifier: -10
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -211,7 +211,6 @@
         Heat: -5
         Shock: -5
         Caustic: -5
-        Mangleness: 1.5 #Sunrise-edit
 
 - type: entity
   parent: CableApcStack

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -8,12 +8,7 @@
     damage:
       types:
         Poison: -0.1
-        Heat: -0.05 #SUNRISE-EDIT
-        Cold: -0.1 #SUNRISE-EDIT
         Blunt: -0.1
-        Piercing: -0.05 #SUNRISE-EDIT
-        Slash: -0.05 #SUNRISE-EDIT
-        Mangleness: -0.02 #SUNRISE-EDIT
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -85,12 +80,8 @@
     damage:
       types:
         Poison: -0.2
-        Heat: -0.1 #SUNRISE-EDIT
         Cold: -0.4
         Blunt: -0.2
-        Piercing: -0.1 #SUNRISE-EDIT
-        Slash: -0.1 #SUNRISE-EDIT
-        Mangleness: -0.1 #SUNRISE-EDIT
   - type: Construction
     graph: bed
     node: medicalbed

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -31,7 +31,6 @@
         damage:
           types:
             Poison: -1
-            Mangleness: 0.1 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -94,7 +93,6 @@
         damage:
           types:
             Poison: -3
-            Mangleness: 0.45 #Sunrise-Edit
 
 - type: reagent
   id: Ethylredoxrazine
@@ -115,7 +113,6 @@
         damage:
           types:
             Poison: -0.5
-            Mangleness: 0.1 #Sunrise-Edit
 
 - type: reagent
   id: Arithrazine
@@ -132,7 +129,6 @@
         damage:
           types:
             Radiation: -3
-            Mangleness: 0.45 #Sunrise-Edit
           groups:
             Brute: 1.5
 
@@ -149,8 +145,6 @@
       effects:
       - !type:HealthChange
         damage:
-          types: #Sunrise-Edit
-            Mangleness: 0.1 #Sunrise-Edit
           groups:
             Brute: -2
       - !type:HealthChange
@@ -201,10 +195,6 @@
               Brute: -4
               Burn: -6
               Toxin: -4
-            #Sunrise-Start
-            types:
-             Mangleness: -0.5
-            #Sunrise-End
 
 - type: reagent
   id: Doxarubixadone
@@ -242,7 +232,6 @@
             Heat: -1.5
             Shock: -1.5
             Cold: -1.5
-            Mangleness: 0.1 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -274,7 +263,6 @@
           types:
             Asphyxiation: -1
             Bloodloss: -0.5
-            Mangleness: 0.05 #Sunrise-Edit
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
@@ -300,7 +288,6 @@
           types:
             Asphyxiation: -3.5
             Bloodloss: -3
-            Mangleness: 0.15 #Sunrise-Edit
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -351,15 +338,6 @@
           groups:
             Brute: -0.5
             Burn: -0.5
-      #Sunrise-Start
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          min: 5
-        damage:
-          types:
-            Mangleness: 0.1
-      #Sunrise-End
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -414,7 +392,6 @@
         damage:
           types:
             Radiation: -1
-            Mangleness: 0.1 #Sunrise-Edit
       - !type:ChemVomit
         probability: 0.02
       - !type:HealthChange
@@ -466,7 +443,6 @@
         damage:
           types:
             Asphyxiation: -2
-            Mangleness: 0.2 #Sunrise-Edit
       - !type:ModifyBleedAmount
         amount: -0.25
 
@@ -487,7 +463,6 @@
             Heat: -0.33
             Shock: -0.33
             Cold: -0.33
-            Mangleness: 0.05 #Sunrise-Edit
       - !type:SatiateThirst
         factor: -10
         conditions:
@@ -519,7 +494,6 @@
         damage:
           types:
             Cold: -4
-            Mangleness: 0.4 #Sunrise-Edit
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
@@ -550,12 +524,6 @@
   metabolisms:
     Medicine:
       effects:
-      #Sunrise-Start
-      - !type:HealthChange
-        damage:
-          types:
-            Mangleness: 0.05
-      #Sunrise-End
       - !type:HealthChange
         probability: 0.3
         damage:
@@ -614,7 +582,6 @@
             Cellular: -0.3
             Radiation: 0.15
             Caustic: 0.15
-            Mangleness: 0.1 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -648,7 +615,6 @@
             Brute: -3.5
           types:
             Asphyxiation: -2.5
-            Mangleness: 0.1 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -717,12 +683,6 @@
   metabolisms:
     Drink:
       effects:
-        #Sunrise-Start
-        - !type:HealthChange
-          damage:
-            types:
-              Mangleness: 0.2
-        #Sunrise-End
         - !type:SatiateThirst
           factor: 6
           conditions:
@@ -747,7 +707,6 @@
         damage:
           types:
             Caustic: -5
-            Mangleness: 0.15 #Sunrise-Edit
 
 - type: reagent
   id: Stellibinin
@@ -764,7 +723,6 @@
         damage:
           types:
             Poison: -4
-            Mangleness: 0.15 #Sunrise-Edit
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -816,12 +774,6 @@
       # but still technically stop your bleeding.
       - !type:ModifyBleedAmount
         amount: -1.5
-      #Sunrise-Start
-      - !type:HealthChange
-        damage:
-          types:
-            Mangleness: 0.3
-        #Sunrise-End
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -853,7 +805,6 @@
             Heat: -0.33
             Shock: -0.33
             Cold: -0.33
-            Mangleness: -0.05 #Sunrise-Edit
 
 - type: reagent
   id: Lipozine
@@ -882,12 +833,6 @@
   metabolisms:
     Medicine:
       effects:
-      #Sunrise-Start
-      - !type:HealthChange
-        damage:
-          types:
-            Mangleness: -0.2
-      #Sunrise-End
       - !type:EvenHealthChange
         damage:
           Burn: -2
@@ -915,10 +860,6 @@
           groups:
             Toxin: -3
             Brute: 0.5
-                #Sunrise-Start
-          types:
-            Mangleness: 0.1
-      #Sunrise-End
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1040,7 +981,6 @@
         damage:
           types:
             Caustic: -3
-            Mangleness: 0.45 # Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1096,7 +1036,6 @@
         damage:
           types:
             Slash: -3
-            Mangleness: 0.3 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1121,7 +1060,6 @@
           types:
             Piercing: -4
             Blunt: 0.1
-            Mangleness: 0.4 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1145,7 +1083,6 @@
         damage:
           types:
             Blunt: -3.5
-            Mangleness: 0.35 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1205,7 +1142,6 @@
             Heat: -0.5
             Shock: -0.5
             Cold: -0.5
-            Mangleness: -0.1
             # Sunrise-End
   reactiveEffects:
     Unholy:
@@ -1252,7 +1188,6 @@
         damage:
           types:
             Heat: -1
-            Mangleness: 0.1 #Sunrise-Edit
       # od causes massive bleeding
       - !type:HealthChange
         conditions:
@@ -1290,7 +1225,6 @@
         damage:
           types:
             Shock: -4
-            Mangleness: 0.6 #Sunrise-Edit
       - !type:AdjustReagent
         reagent: Licoxide
         amount: -4
@@ -1367,7 +1301,6 @@
               Burn: -5
             types:
               Poison: -2
-              Mangleness: -0.5 #Sunrise-Edit
 
 - type: reagent
   id : Aloxadone

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -15,7 +15,6 @@
         damage:
           types:
             Poison: 0.75
-            Mangleness: 0.15 #Sunrise-Edit
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -72,12 +71,6 @@
       - !type:MovespeedModifier
         walkSpeedModifier: 1.25
         sprintSpeedModifier: 1.25
-      #Sunrise-Start
-      - !type:HealthChange
-        damage:
-          types:
-            Mangleness: 0.05
-      #Sunrise-End
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -132,12 +125,6 @@
       - !type:MovespeedModifier
         walkSpeedModifier: 1.3
         sprintSpeedModifier: 1.3
-      #Sunrise-Start
-      - !type:HealthChange
-        damage:
-          types:
-            Mangleness: 0.1
-      #Sunrise-End
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold

--- a/Resources/Prototypes/_Sunrise/Chemistry/medicine.yml
+++ b/Resources/Prototypes/_Sunrise/Chemistry/medicine.yml
@@ -16,10 +16,6 @@
           groups:
             Brute: -3.2
       - !type:HealthChange
-        damage:
-          types:
-            Mangleness: 0.2
-      - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 10.1

--- a/Resources/Prototypes/_Sunrise/Damage/containers.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/containers.yml
@@ -7,7 +7,6 @@
   - Shock
   - Caustic
   - Structural
-  - Mangleness
 
 - type: damageContainer
   id: Mech
@@ -18,7 +17,6 @@
   - Shock
   - Caustic
   - Structural
-  - Mangleness
 
 - type: damageContainer
   id: Rift

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Mech/mechs.yml
@@ -43,7 +43,6 @@
         Piercing: -15
         Caustic: -15
         Structural: -15
-        Mangleness: 7.5
   - type: UserInterface
     interfaces:
       enum.MechUiKey.Key:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Robotics/nanopaste.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Robotics/nanopaste.yml
@@ -15,6 +15,7 @@
     heldPrefix: nanopaste
   - type: Healing
     damageContainers:
+    - Mech
     - Synth
     - Silicon
     damage:
@@ -24,7 +25,6 @@
         Blunt: -10
         Slash: -10
         Piercing: -10
-        Mangleness: -10
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:

--- a/Resources/Prototypes/_Sunrise/Reagents/gases.yml
+++ b/Resources/Prototypes/_Sunrise/Reagents/gases.yml
@@ -179,15 +179,6 @@
         sprintSpeedModifier: 1.4
       - !type:HealthChange
         conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 0.5
-        ignoreResistances: true
-        damage:
-          types:
-            Mangleness: 0.4
-      - !type:HealthChange
-        conditions:
           - !type:ReagentThreshold
             min: 80
         damage:

--- a/Resources/Prototypes/_Sunrise/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Sunrise/Reagents/narcotics.yml
@@ -15,7 +15,6 @@
         damage:
           types:
             Poison: 0.65
-            Mangleness: 0.3
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
Reverts space-sunrise/sunrise-station#2646

В связи с https://github.com/space-wizards/space-station-14/pull/38811

Так как лекарства больше не позволяют полностью вылечиться за 10 секунд, я считаю этот нерф более не нужен.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения в функциональности**
  * Удалён тип урона "Mangleness" из всех игровых механик, предметов, реагентов, медицинских и ремонтных систем.
  * Удалены все эффекты лечения и нанесения урона, связанные с "Mangleness".
  * Обновлены локализации: соответствующие строки для "Mangleness" удалены из английской и русской версий.

* **Обновление документации**
  * Очищены описания и конфигурационные файлы от упоминаний типа урона "Mangleness".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->