### PR TITLE
Рапира + Сабля капитошки

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -174,7 +174,7 @@
         Piercing: 0.3
         Heat: 0.9
   - type: ExplosionResistance
-    damageCoefficient: 0.9
+    damageCoefficient: 0.7
   - type: StaticPrice
     price: 1500
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -92,14 +92,13 @@
   - type: Reflect
     reflects:
     - NonEnergy
-    reflectProb: 0.20
+    reflectProb: 0.35
     spread: 90
   - type: Item
     storedSprite:
       state: storage
       sprite: Objects/Weapons/Melee/captain_sabre_storage_64x.rsi #Done in 64x64 because it looks way too puny in 32x32
-    shape:
-    - 0,0,0,4 # Sunrise edit
+    size: Ginormous # Sunrise edit
   - type: Tag
     tags:
     - CaptainSabre

--- a/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
@@ -923,6 +923,11 @@
     Telecrystal: 10
   categories:
   - UplinkWeaponry
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
 
 - type: listing
   id: UplinkFireAxeFlaming

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
@@ -17,7 +17,6 @@
       types:
         Piercing: 17
     resistanceBypass: true
-    resistanceBypassOnWide: true
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: SolutionContainerManager
@@ -35,14 +34,13 @@
   - type: Reflect
     reflects:
     - NonEnergy
-    reflectProb: 0.20
+    reflectProb: 0.5
     spread: 90
   - type: Item
+    size: Ginormous
     storedSprite:
       state: storage
       sprite: _Sunrise/Objects/Weapons/Melee/syndicate_rapier_storage_64x.rsi
-    shape:
-    - 0,0,0,4 #1x5
   - type: Tag
     tags:
     - SyndicateRapier


### PR DESCRIPTION


## Кратное описание
Сабля капитана получила отражение в 35 процентов, можно носить только в ножнах
Рапира синдиката получила отражение в 50 процентов, можно носить только в ножнах
Рапира синдиката лишилась пробития на ПКМ
Рапира синдиката была убрана из аплинка ядерных оперативников
Тактический жилет получил 30 процентов защиты от взрывов, было 10

## По какой причине
Рапира и Сабля - приказал разраб
Тактик - офицеры решили шахедатся в агентов, которые не имели какой либо защиты от взрывов, чуть изменил ситуацию

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: Dextor
- tweak: Капитанская сабля получила отражение в 35 процентов, так же носить можно только в ножнах
- tweak: Рапира Синдиката  получила отражение в 50 процентов, так же носить можно только в ножнах, так же была убрана в аплинке ядерных оперативников и лишилась пробития на ПКМ
- tweak: Тактический жилет получил небольшой бафф в защите от взрывов.
-->
