### PR TITLE
Исправление цвара для панельки

### DIFF
--- a/Content.Shared/_Sunrise/InteractionsPanel/Data/UI/BUI.cs
+++ b/Content.Shared/_Sunrise/InteractionsPanel/Data/UI/BUI.cs
@@ -75,7 +75,7 @@ public sealed class CustomInteractionData
 public sealed class InteractionsCVars
 {
     public static readonly CVarDef<bool> EmoteVisibility =
-        CVarDef.Create("interactions.emote", true, CVar.CLIENTONLY);
+        CVarDef.Create("interactions.emote", true, CVar.CLIENT);
 
     public static readonly CVarDef<bool> Expand =
         CVarDef.Create("interactions.expand", false, CVar.CLIENTONLY);


### PR DESCRIPTION
В коммите 2b3750ab0e1f5faeae835fac9b850aff78f3845f вигерс сломал (ерп) панель. Если вкратце, то одна из этих переменных запрашивается на сервере чтоб определить, проигрывать ли эмоцию, или нет. А вигерс сделал этот цвар CLIENTONLY, что делает запрос его с сервера невозможным. Пока делал апстрим ласта заметил.

Как-то так