### PR TITLE
Фикс рапиры Синдиката

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
@@ -30,7 +30,7 @@
   - type: InjectableSolution
     solution: melee
   - type: SolutionTransfer
-    maxTransferAmount: 1
+    maxTransferAmount: 0.5
   - type: Reflect
     reflects:
     - NonEnergy


### PR DESCRIPTION
Фикс рапиры синдиката, а то поахуевали "Робасты" паксом ебашить всех подряд


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Баланс
  - Уменьшен объём переносимой субстанции у рапиры Синдиката: теперь при взаимодействиях переносится вдвое меньше раствора. Это снижает эффективность быстрой передачи ядов/реагентов и делает применение более дозированным, уменьшая риск случайного передозирования целей.
  - Изменение не требует действий со стороны игроков; игровые механики и интерфейс остаются прежними, корректировка затрагивает только количество передаваемого вещества за одно действие.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->