### PR TITLE
Фикс украинского акцента и ТТСа

### DIFF
--- a/Content.Server/_Sunrise/Speech/EntitySystems/UkrainianAccentSystem.cs
+++ b/Content.Server/_Sunrise/Speech/EntitySystems/UkrainianAccentSystem.cs
@@ -49,11 +49,11 @@ public sealed class UkrainianAccentSystem : EntitySystem
     private void OnSanitize(EntityUid uid, UkrainianAccentComponent component, TTSSanitizeEvent args)
     {
         var text = args.Text.Trim();
-        text = Regex.Replace(text, "[іІ]", "и");
-        text = Regex.Replace(text, "[їЇ]", "ё");
-        text = Regex.Replace(text, "[єЄ]", "е");
-        text = Regex.Replace(text, "[ґҐ]", "г");
-        text = Regex.Replace(text, "[еЕ]", "э");
+        text = Regex.Replace(text, "[іІ]", "[иИ]");
+        text = Regex.Replace(text, "[їЇ]", "[ёЁ]");
+        text = Regex.Replace(text, "[єЄ]", "[еЕ]");
+        text = Regex.Replace(text, "[ґҐ]", "[гГ]");
+        text = Regex.Replace(text, "[еЕ]", "[эЭ]");
         text = text.Trim();
         args.Text = text;
     }

--- a/Content.Server/_Sunrise/TTS/TTSSystem.Sanitize.cs
+++ b/Content.Server/_Sunrise/TTS/TTSSystem.Sanitize.cs
@@ -16,7 +16,6 @@ public sealed partial class TTSSystem
     private string Sanitize(string text)
     {
         text = text.Trim();
-        text = Regex.Replace(text, "[еЕ]", "э");
         text = Regex.Replace(text, @"[^a-zA-Zа-яА-ЯёЁ0-9,\-+?!. ]", "");
         text = Regex.Replace(text, @"[a-zA-Z]", ReplaceLat2Cyr, RegexOptions.Multiline | RegexOptions.IgnoreCase);
         text = Regex.Replace(text, @"(?<![a-zA-Zа-яёА-ЯЁ])[a-zA-Zа-яёА-ЯЁ]+?(?![a-zA-Zа-яёА-ЯЁ])", ReplaceMatchedWord, RegexOptions.Multiline | RegexOptions.IgnoreCase);


### PR DESCRIPTION
Буковки там вырезал чтобы ТТС не менял
Фиксанул украинский, чтобы заглавные буковки также менялись на какие буквы? Правильно, заглавные.

**Changelog**

:cl: ReWAFFlution
- fix: Починил ТТС. Теперь без "Э", вместо "Е".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Улучшена обработка украинского акцента: корректнее отображаются буквы с учетом регистра (е/ё/э/г/и), что делает реплики более естественными.

- Исправления ошибок
  - В озвучке (TTS) убрано принудительное преобразование «е/Е» в «э», сохраняя оригинальное написание и улучшая произношение.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->