### PR TITLE
Ликоксид с тазинидом теперь работают с 1 унции.

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -165,6 +165,9 @@
       effects:
       - !type:Electrocute
         probability: 0.35
+        conditions: # Sunrise-Edit
+        - !type:ReagentThreshold
+          min: 1
 
 - type: reagent
   id: Razorium

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -667,6 +667,9 @@
       effects:
       - !type:Electrocute
         probability: 0.8
+        conditions: # Sunrise-Edit
+        - !type:ReagentThreshold
+          min: 1
 
 - type: reagent
   id: Lipolicide


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Ликоксид с тазинидом теперь работают с 1 унции.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Ликоксид с тазинидом раньше работали даже при 0.01 унции, это ну просто пиздец, я думаю обьяснять почему не стоит.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: banumbas
- fix: Ликоксид с тазинидом теперь работают с 1 унции, а не любом количестве.