### PR TITLE
Фикс рапиры

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -72,12 +72,6 @@ public sealed partial class MeleeWeaponComponent : Component
     public bool ResistanceBypass = false;
 
     /// <summary>
-    /// Sunrise Edit bypass OnWide
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool ResistanceBypassOnWide = false;
-
-    /// <summary>
     /// Base damage for this weapon. Can be modified via heavy damage or other means.
     /// </summary>
     [DataField(required: true), AutoNetworkedField]

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -470,7 +470,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         // If I do not come back later to fix Light Attacks being Heavy Attacks you can throw me in the spider pit -Errant
         var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
         var target = GetEntity(ev.Target);
-        var resistanceBypass = GetResistanceBypass(meleeUid, user, component);
 
         // For consistency with wide attacks stuff needs damageable.
         if (Deleted(target) ||
@@ -529,6 +528,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         RaiseLocalEvent(target.Value, attackedEvent);
 
         var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
+var resistanceBypass = GetResistanceBypass(meleeUid, user, component); // Sunrise-edit ЛКМ пробивает броню
         var damageResult = Damageable.TryChangeDamage(target, modifiedDamage, origin:user, ignoreResistances:resistanceBypass);
 
         if (damageResult is {Empty: false})
@@ -580,7 +580,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         var distance = Math.Min(component.Range, direction.Length());
 
         var damage = GetDamage(meleeUid, user, component);
-        var resistanceBypass = GetResistanceBypass(meleeUid, user, component);
+        var resistanceBypass = false; // Sunrise-edit ЛКМ пробивает броню
         var entities = GetEntityList(ev.Entities);
 
         entities = entities.Where(e => !_tagSystem.HasTag(e, "IgnoreMelee")).ToList(); //Sunrise-edit

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -580,7 +580,7 @@ var resistanceBypass = GetResistanceBypass(meleeUid, user, component); // Sunris
         var distance = Math.Min(component.Range, direction.Length());
 
         var damage = GetDamage(meleeUid, user, component);
-        var resistanceBypass = false; // Sunrise-edit ЛКМ пробивает броню
+        var resistanceBypass = false; // Sunrise-edit ПКМ не пробивает броню
         var entities = GetEntityList(ev.Entities);
 
         entities = entities.Where(e => !_tagSystem.HasTag(e, "IgnoreMelee")).ToList(); //Sunrise-edit

--- a/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
@@ -915,11 +915,6 @@
     Telecrystal: 10
   categories:
   - UplinkWeaponry
-  conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
 
 - type: listing
   id: UplinkFireAxeFlaming

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
@@ -30,7 +30,7 @@
   - type: InjectableSolution
     solution: melee
   - type: SolutionTransfer
-    maxTransferAmount: 0.75
+    maxTransferAmount: 1
   - type: Reflect
     reflects:
     - NonEnergy

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/sword.yml
@@ -30,7 +30,7 @@
   - type: InjectableSolution
     solution: melee
   - type: SolutionTransfer
-    maxTransferAmount: 1
+    maxTransferAmount: 0.75
   - type: Reflect
     reflects:
     - NonEnergy

--- a/Resources/Prototypes/_Sunrise/FleshCult/hands_mods.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/hands_mods.yml
@@ -117,7 +117,6 @@
         types:
           Piercing: 19
       resistanceBypass: true
-      resistanceBypassOnWide: true
       soundHit:
           path: /Audio/Weapons/bladeslice.ogg
     - type: Item


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Долгожданный фикс рапиры, в котором она перестала пробивать броню на ПКМ, однако всё также пробивает броню на ЛКМ. Переработал систему пробивания, в котором ЛКМ пробивает броню, а ПКМ нет.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Рапира обрела огромную популярность у простых людей, имея способность пробивать броню на ПКМ при любых резистах, с огромным отражением урона, а также со способностью передавать химикаты внутри себя, аж в целую унцию(теперь уже 0,75)!

**Changelog**

:cl: ReWAFFlution
- fix: Рапира теперь вновь пробивает броню только на ЛКМ.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Изменения геймплея
  * Пробитие брони для лёгких ударов теперь определяется непосредственно при нанесении урона.
  * Тяжёлые удары больше не обходят сопротивления.
  * Широкие взмахи больше не обходят сопротивления.

* Баланс
  * Уменьшено максимальное переносимое количество раствора у рапиры Синдиката: с 1 до 0.75.
  * У клинка «плоти» убран обход сопротивлений при широком взмахе; обычное пробитие сохранено.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->