### PR TITLE
Ребаланс скорости лечения во сне

### DIFF
--- a/Content.Shared/Bed/Components/HealOnBuckleComponent.cs
+++ b/Content.Shared/Bed/Components/HealOnBuckleComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Shared.Bed.Components
         /// Damage multiplier that gets applied if the entity is sleeping.
         /// </summary>
         [DataField]
-        public float SleepMultiplier = 3f;
+        public float SleepMultiplier = 1.5f;
 
         /// <summary>
         /// Next time that <see cref="Damage"/> will be applied.

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -86,7 +86,7 @@
       types:
         Poison: -0.2
         Heat: -0.1 #SUNRISE-EDIT
-        Cold: -0.4
+        Cold: -0.2 #SUNRISE-EDIT
         Blunt: -0.2
         Piercing: -0.1 #SUNRISE-EDIT
         Slash: -0.1 #SUNRISE-EDIT

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -13,7 +13,7 @@
         Blunt: -0.1
         Piercing: -0.05 #SUNRISE-EDIT
         Slash: -0.05 #SUNRISE-EDIT
-        Mangleness: -0.02 #SUNRISE-EDIT
+        Mangleness: -0.05 #SUNRISE-EDIT
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -90,7 +90,7 @@
         Blunt: -0.2
         Piercing: -0.1 #SUNRISE-EDIT
         Slash: -0.1 #SUNRISE-EDIT
-        Mangleness: -0.1 #SUNRISE-EDIT
+        Mangleness: -0.15 #SUNRISE-EDIT
   - type: Construction
     graph: bed
     node: medicalbed


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Снижен модификатор скорости лечения во сне для компонента HealOnBuckle до 1.5
Так же немного повышена скорость лечения истощения для отдыха на кроватях, понижена скорость лечения обморожения.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Слишком сильные по моему мнению показатели лечения для обычного сна на кровати, пусть и медицинской. По 0.6 ушиба, 1.2 обморожения, 0.6 яда за тик. С такими кроватями можно обойтись без помощи врачей.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Баланс
  - Снижен общий множитель исцеления во сне: восстановление при лежании/пристёгивании происходит медленнее.
  - Обычная кровать теперь быстрее лечит ушибы/повреждения мягких тканей.
  - Медицинская кровать медленнее справляется с переохлаждением, но эффективнее устраняет ушибы.
  - В целом изменены темпы лечения на кроватях для более предсказуемого восстановления разных типов урона.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->