### PR TITLE
Добавить возможность выключать пищание мониторинга

### DIFF
--- a/Content.Server/Atmos/Consoles/AtmosAlertsComputerSystem.cs
+++ b/Content.Server/Atmos/Consoles/AtmosAlertsComputerSystem.cs
@@ -231,7 +231,7 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
     private void Beep(EntityUid ent, AtmosAlertsComputerComponent entConsole, AtmosAlarmType highestAlert)
     {
         if (entConsole.NextBeep >= _gameTiming.CurTime || highestAlert != AtmosAlarmType.Danger ||
-            entConsole.BeepSound == null || !entConsole.DoAtmosAlert) 
+            entConsole.BeepSound == null || !entConsole.DoAtmosAlert) //Sunrise-Edit
             return;
 
         _audio.PlayPvs(entConsole.BeepSound, ent);

--- a/Content.Server/Atmos/Consoles/AtmosAlertsComputerSystem.cs
+++ b/Content.Server/Atmos/Consoles/AtmosAlertsComputerSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Atmos.Monitor;
 using Content.Shared.Atmos.Monitor.Components;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Pinpointer;
+using Content.Shared.Verbs; //Sunrise-Edit
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
 using System.Diagnostics.CodeAnalysis;
@@ -21,6 +22,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility; //Sunrise-Edit
 
 namespace Content.Server.Atmos.Monitor.Systems;
 
@@ -51,6 +53,7 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
         SubscribeLocalEvent<AtmosAlertsComputerComponent, ComponentInit>(OnConsoleInit);
         SubscribeLocalEvent<AtmosAlertsComputerComponent, EntParentChangedMessage>(OnConsoleParentChanged);
         SubscribeLocalEvent<AtmosAlertsComputerComponent, AtmosAlertsComputerFocusChangeMessage>(OnFocusChangedMessage);
+        SubscribeLocalEvent<AtmosAlertsComputerComponent, GetVerbsEvent<InteractionVerb>>(AddToggleVerb); //Sunrise-Edit
 
         // Grid events
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
@@ -58,6 +61,7 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
         // Alarm events
         SubscribeLocalEvent<AtmosAlertsDeviceComponent, EntityTerminatingEvent>(OnDeviceTerminatingEvent);
         SubscribeLocalEvent<AtmosAlertsDeviceComponent, AnchorStateChangedEvent>(OnDeviceAnchorChanged);
+
     }
 
     #region Event handling
@@ -227,7 +231,7 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
     private void Beep(EntityUid ent, AtmosAlertsComputerComponent entConsole, AtmosAlarmType highestAlert)
     {
         if (entConsole.NextBeep >= _gameTiming.CurTime || highestAlert != AtmosAlarmType.Danger ||
-            entConsole.BeepSound == null)
+            entConsole.BeepSound == null || !entConsole.DoAtmosAlert) 
             return;
 
         _audio.PlayPvs(entConsole.BeepSound, ent);
@@ -448,4 +452,36 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
 
         Dirty(uid, component);
     }
+    //Sunrise-Start
+    private void AddToggleVerb(EntityUid uid, AtmosAlertsComputerComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        InteractionVerb verb = new();
+        if (component.DoAtmosAlert)
+        {
+            verb.Text = Loc.GetString("item-toggle-deactivate-alert");
+        }
+        else
+        {
+            verb.Text = Loc.GetString("item-toggle-activate-alert");
+        }
+        verb.Act = () => ToggleAlert(uid, component);
+        args.Verbs.Add(verb);
+    }
+
+    public void ToggleAlert(EntityUid uid, AtmosAlertsComputerComponent component)
+    {
+        if (component.DoAtmosAlert)
+        {
+            component.DoAtmosAlert = false;
+        }
+        else
+        {
+            component.DoAtmosAlert = true;
+        }
+        Dirty(uid, component);
+    }
+    //Sunrise-End
 }

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
@@ -23,7 +23,7 @@ public sealed partial class CrewMonitoringConsoleComponent : Component
     ///     Whether the console should beep when corpses with sensors are detected outside morgues.
     /// </summary>
     [DataField("doCorpseAlert"), ViewVariables(VVAccess.ReadWrite)]
-    public bool DoCorpseAlert = true;
+    public bool DoCorpseAlert = false;
 
     /// <summary>
     ///     Next time to check for corpses and potentially play alert sound.

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -10,13 +10,17 @@ using Content.Shared.Medical.CrewMonitoring;
 using Content.Shared.Medical.SuitSensor;
 using Content.Shared.Morgue.Components;
 using Content.Shared.Pinpointer;
+using Content.Server.Power.EntitySystems;//Sunrise-Edit
+using Content.Shared.Power.Components;//Sunrise-Edit
+using Content.Shared.PowerCell;//Sunrise-Edit
+using Content.Shared.UserInterface;//Sunrise-Edit
 using Content.Shared.Storage.Components;
-using Content.Shared.Verbs;
+using Content.Shared.Verbs;//Sunrise-Edit
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
+using Robust.Shared.Utility;//Sunrise-Edit
 
 namespace Content.Server.Medical.CrewMonitoring;
 
@@ -33,7 +37,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, BoundUIOpenedEvent>(OnUIOpened);
-        SubscribeLocalEvent<CrewMonitoringConsoleComponent, GetVerbsEvent<InteractionVerb>>(AddToggleVerb);
+        SubscribeLocalEvent<CrewMonitoringConsoleComponent, GetVerbsEvent<InteractionVerb>>(AddToggleVerb);//Sunrise-Edit
     }
 
     public override void Update(float frameTime)
@@ -54,7 +58,20 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
             // Check for corpses with sensors outside morgues
             if (HasCorpsesOutsideMorgue(component))
             {
-                _audio.PlayPvs(component.CorpseAlertSound, uid);
+                if (HasComp<ActivatableUIRequiresPowerCellComponent>(uid) && TryComp<PowerCellDrawComponent>(uid, out var draw))
+                {
+                    if (_cell.HasActivatableCharge(uid, draw))
+                    {
+                        _audio.PlayPvs(component.CorpseAlertSound, uid);
+                    }
+                }
+                if (HasComp<ActivatableUIRequiresPowerComponent>(uid))
+                {
+                    if (this.IsPowered(uid, EntityManager))
+                    {
+                        _audio.PlayPvs(component.CorpseAlertSound, uid);
+                    }
+                }
             }
         }
     }
@@ -161,7 +178,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
 
         return false;
     }
-
+    //Sunrise-Start
     private void AddToggleVerb(EntityUid uid, CrewMonitoringConsoleComponent component, GetVerbsEvent<InteractionVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess)
@@ -176,11 +193,11 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         {
             verb.Text = Loc.GetString("item-toggle-activate-alert");
         }
-        verb.Act = () => ToggleAlert(component);
+        verb.Act = () => ToggleAlert(uid, component);
         args.Verbs.Add(verb);
     }
 
-    public void ToggleAlert(CrewMonitoringConsoleComponent component)
+    public void ToggleAlert(EntityUid uid, CrewMonitoringConsoleComponent component)
     {
         if (component.DoCorpseAlert)
         {
@@ -190,6 +207,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         {
             component.DoCorpseAlert = true;
         }
+        Dirty(uid, component);
     }
-
+    //Sunrise-End
 }

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -11,10 +11,12 @@ using Content.Shared.Medical.SuitSensor;
 using Content.Shared.Morgue.Components;
 using Content.Shared.Pinpointer;
 using Content.Shared.Storage.Components;
+using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Medical.CrewMonitoring;
 
@@ -31,6 +33,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, BoundUIOpenedEvent>(OnUIOpened);
+        SubscribeLocalEvent<CrewMonitoringConsoleComponent, GetVerbsEvent<InteractionVerb>>(AddToggleVerb);
     }
 
     public override void Update(float frameTime)
@@ -158,4 +161,35 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
 
         return false;
     }
+
+    private void AddToggleVerb(EntityUid uid, CrewMonitoringConsoleComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        InteractionVerb verb = new();
+        if (component.DoCorpseAlert)
+        {
+            verb.Text = Loc.GetString("item-toggle-deactivate-alert");
+        }
+        else
+        {
+            verb.Text = Loc.GetString("item-toggle-activate-alert");
+        }
+        verb.Act = () => ToggleAlert(component);
+        args.Verbs.Add(verb);
+    }
+
+    public void ToggleAlert(CrewMonitoringConsoleComponent component)
+    {
+        if (component.DoCorpseAlert)
+        {
+            component.DoCorpseAlert = false;
+        }
+        else
+        {
+            component.DoCorpseAlert = true;
+        }
+    }
+
 }

--- a/Content.Shared/Atmos/Consoles/Components/AtmosAlertsComputerComponent.cs
+++ b/Content.Shared/Atmos/Consoles/Components/AtmosAlertsComputerComponent.cs
@@ -38,6 +38,9 @@ public sealed partial class AtmosAlertsComputerComponent : Component
 
     [DataField]
     public TimeSpan NextBeep = TimeSpan.Zero;
+
+    [DataField]
+    public bool DoAtmosAlert = true;
     // Sunrise-end
 }
 

--- a/Resources/Locale/en-US/_strings/_sunrise/toggle-alert/toggle-alert.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/toggle-alert/toggle-alert.ftl
@@ -1,0 +1,2 @@
+item-toggle-deactivate-alert = Deactivate alert
+item-toggle-activate-alert = Activate alert

--- a/Resources/Locale/ru-RU/_strings/_sunrise/toggle-alert/toggle-alert.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/toggle-alert/toggle-alert.ftl
@@ -1,0 +1,2 @@
+item-toggle-deactivate-alert = Деактивировать тревогу
+item-toggle-activate-alert = Активировать тревогу

--- a/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
@@ -7,6 +7,6 @@
   - type: ItemToggle
     onUse: false # above component does the toggling
   - type: PowerCellDraw
-    drawRate: 0
+    drawRate: 2 #Sunrise-Edit
     useRate: 20
   - type: ToggleCellDraw


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Сильно бесит это пищание, а так же то, что пищат даже консоли и борги. Система требует полной переработки чтобы мониторинг пищал когда меняется состояние на крит/смерть с опциональным звуковым различием в зависимости от отдела пострадавшего и того упал он в крит или умер.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="554" height="171" alt="image" src="https://github.com/user-attachments/assets/0db4a1c6-8856-4a81-a6df-25f07d5d909f" />

<img width="550" height="168" alt="image" src="https://github.com/user-attachments/assets/ab26158d-9dd8-4c7a-915c-e7f9db7a769f" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлены контекстные действия на консоли мониторинга экипажа и атмоса для включения/выключения звуковых оповещений (локализованные подписи).
* **Изменения поведения**
  * По умолчанию оповещение о найденных телах отключено; можно включать вручную.
  * Звуковые сигналы теперь учитывают состояние питания/аккумулятора и не срабатывают при отсутствии питания.
* **Прочее**
  * Добавлены локализации для переключателя оповещений (en-US, ru-RU).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->