### PR TITLE
Miso soup recipe add

### DIFF
--- a/Resources/Prototypes/_Sunrise/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Cooking/meal_recipes.yml
@@ -5,3 +5,15 @@
   time: 10
   solids:
     CannabisVitaLeaves: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMiso
+  name: miso recipe
+  result: FoodSoupMiso
+  time: 15
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodTofuSlice: 1


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Теперь у Мисо супа есть рецепт. 10 единиц вода, ломтик тофу и 15 секунд в микроволновке.

## По какой причине
Предложение от игрока.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Добавлен рецепт микроволновки: мисо‑суп (категория «Супы»), время приготовления — 15 секунд.
  - Требуемые ингредиенты: вода, большая миска и ломтик тофу; результат — мисо‑суп.
  - Рецепт появляется в списке доступных блюд микроволновки и готовится стандартным способом.
  - Изменений существующих рецептов нет; добавление не влияет на текущие блюда и совместимо с имеющимися ингредиентами.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->