### PR TITLE
Переработка сигнализации мониторинга экипажа

### DIFF
--- a/Content.Server/Atmos/Consoles/AtmosAlertsComputerSystem.cs
+++ b/Content.Server/Atmos/Consoles/AtmosAlertsComputerSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Atmos.Monitor;
 using Content.Shared.Atmos.Monitor.Components;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Pinpointer;
+using Content.Shared.Verbs; //Sunrise-Edit
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
 using System.Diagnostics.CodeAnalysis;
@@ -21,6 +22,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility; //Sunrise-Edit
 
 namespace Content.Server.Atmos.Monitor.Systems;
 
@@ -51,6 +53,7 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
         SubscribeLocalEvent<AtmosAlertsComputerComponent, ComponentInit>(OnConsoleInit);
         SubscribeLocalEvent<AtmosAlertsComputerComponent, EntParentChangedMessage>(OnConsoleParentChanged);
         SubscribeLocalEvent<AtmosAlertsComputerComponent, AtmosAlertsComputerFocusChangeMessage>(OnFocusChangedMessage);
+        SubscribeLocalEvent<AtmosAlertsComputerComponent, GetVerbsEvent<InteractionVerb>>(AddToggleVerb); //Sunrise-Edit
 
         // Grid events
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
@@ -227,7 +230,7 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
     private void Beep(EntityUid ent, AtmosAlertsComputerComponent entConsole, AtmosAlarmType highestAlert)
     {
         if (entConsole.NextBeep >= _gameTiming.CurTime || highestAlert != AtmosAlarmType.Danger ||
-            entConsole.BeepSound == null)
+            entConsole.BeepSound == null || !entConsole.DoAtmosAlert) //Sunrise-Edit
             return;
 
         _audio.PlayPvs(entConsole.BeepSound, ent);
@@ -448,4 +451,37 @@ public sealed class AtmosAlertsComputerSystem : SharedAtmosAlertsComputerSystem
 
         Dirty(uid, component);
     }
+
+    //Sunrise-Start
+    private void AddToggleVerb(EntityUid uid, AtmosAlertsComputerComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        InteractionVerb verb = new();
+        if (component.DoAtmosAlert)
+        {
+            verb.Text = Loc.GetString("item-toggle-deactivate-alert");
+        }
+        else
+        {
+            verb.Text = Loc.GetString("item-toggle-activate-alert");
+        }
+        verb.Act = () => ToggleAlert(uid, component);
+        args.Verbs.Add(verb);
+    }
+
+    public void ToggleAlert(EntityUid uid, AtmosAlertsComputerComponent component)
+    {
+        if (component.DoAtmosAlert)
+        {
+            component.DoAtmosAlert = false;
+        }
+        else
+        {
+            component.DoAtmosAlert = true;
+        }
+        Dirty(uid, component);
+    }
+    //Sunrise-End
 }

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -10,15 +10,22 @@ using Content.Shared.Medical.CrewMonitoring;
 using Content.Shared.Medical.SuitSensor;
 using Content.Shared.Morgue.Components;
 using Content.Shared.Pinpointer;
+using Content.Server.Power.EntitySystems;//Sunrise-Edit
+using Content.Shared.Power.Components;//Sunrise-Edit
+using Content.Shared.PowerCell;//Sunrise-Edit
+using Content.Shared.UserInterface;//Sunrise-Edit
 using Content.Shared.Storage.Components;
+using Content.Shared.Verbs;//Sunrise-Edit
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
+using Content.Shared._Sunrise.Medical;
+using Robust.Shared.Utility;//Sunrise-Edit
 
 namespace Content.Server.Medical.CrewMonitoring;
 
-public sealed class CrewMonitoringConsoleSystem : EntitySystem
+public sealed class CrewMonitoringConsoleSystem : SharedCrewMonitoringConsoleSystem
 {
     [Dependency] private readonly PowerCellSystem _cell = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
@@ -31,6 +38,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, BoundUIOpenedEvent>(OnUIOpened);
+        SubscribeLocalEvent<CrewMonitoringConsoleComponent, GetVerbsEvent<Verb>>(AddToggleVerb);//Sunrise-Edit
     }
 
     public override void Update(float frameTime)
@@ -40,7 +48,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         var query = EntityQueryEnumerator<CrewMonitoringConsoleComponent>();
         while (query.MoveNext(out var uid, out var component))
         {
-            if (!component.DoCorpseAlert)
+            if (component.Mode == CrewMonitoringMode.ToggleOff || component.Mode == CrewMonitoringMode.StateChanged)
                 continue;
 
             if (component.NextCorpseAlertTime > _gameTiming.CurTime)
@@ -51,7 +59,22 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
             // Check for corpses with sensors outside morgues
             if (HasCorpsesOutsideMorgue(component))
             {
-                _audio.PlayPvs(component.CorpseAlertSound, uid);
+                if (HasComp<ActivatableUIRequiresPowerCellComponent>(uid) && TryComp<PowerCellDrawComponent>(uid, out var draw))
+                {
+                    if (_cell.HasActivatableCharge(uid, draw))
+                    {
+                        _audio.PlayPvs(component.CorpseAlertSound, uid);
+                        continue;
+                    }
+                }
+                if (HasComp<ActivatableUIRequiresPowerComponent>(uid))
+                {
+                    if (this.IsPowered(uid, EntityManager))
+                    {
+                        _audio.PlayPvs(component.CorpseAlertSound, uid);
+                        continue;
+                    }
+                }
             }
         }
     }
@@ -158,4 +181,99 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
 
         return false;
     }
+
+    //Sunrise-Start
+
+    private void AddToggleVerb(Entity<CrewMonitoringConsoleComponent> ent, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+
+        args.Verbs.UnionWith(new[]
+        {
+            CreateVerb(ent, args.User, CrewMonitoringMode.ToggleOff),
+            CreateVerb(ent, args.User, CrewMonitoringMode.StateChanged),
+            CreateVerb(ent, args.User, CrewMonitoringMode.AnyoneDead),
+            CreateVerb(ent, args.User, CrewMonitoringMode.Both)
+        });
+    }
+
+    private Verb CreateVerb(Entity<CrewMonitoringConsoleComponent> ent, EntityUid userUid, CrewMonitoringMode mode)
+    {
+        return new Verb()
+        {
+            Text = GetModeName(mode),
+            Disabled = ent.Comp.Mode == mode,
+            Priority = -(int)mode, // sort them in descending order
+            Category = VerbCategory.SetCrewMonitoring,
+            Act = () => SetSensor(ent.AsNullable(), mode)
+        };
+    }
+
+    public void SetSensor(Entity<CrewMonitoringConsoleComponent?> monitor, CrewMonitoringMode mode)
+    {
+        if (!Resolve(monitor, ref monitor.Comp, false))
+            return;
+
+        monitor.Comp.Mode = mode;
+        Dirty(monitor);
+    }
+
+    public string GetModeName(CrewMonitoringMode mode)
+    {
+        string name;
+        switch (mode)
+        {
+            case CrewMonitoringMode.ToggleOff:
+                name = "crew-monitoring-mode-ToggleOff";
+                break;
+            case CrewMonitoringMode.StateChanged:
+                name = "crew-monitoring-mode-StateChanged";
+                break;
+            case CrewMonitoringMode.AnyoneDead:
+                name = "crew-monitoring-mode-AnyoneDead";
+                break;
+            case CrewMonitoringMode.Both:
+                name = "crew-monitoring-mode-Both";
+                break;
+            default:
+                return "";
+        }
+
+        return Loc.GetString(name);
+    }
+/*
+    private void AddToggleVerb(EntityUid uid, CrewMonitoringConsoleComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        InteractionVerb verb = new();
+        if (component.DoCorpseAlert)
+        {
+            verb.Text = Loc.GetString("item-toggle-deactivate-alert");
+        }
+        else
+        {
+            verb.Text = Loc.GetString("item-toggle-activate-alert");
+        }
+        verb.Act = () => ToggleAlert(uid, component);
+        args.Verbs.Add(verb);
+    }
+
+    public void ToggleAlert(EntityUid uid, CrewMonitoringConsoleComponent component)
+    {
+        if (component.DoCorpseAlert)
+        {
+            component.DoCorpseAlert = false;
+        }
+        else
+        {
+            component.DoCorpseAlert = true;
+        }
+        Dirty(uid, component);
+    }
+    //Sunrise-End
+    */
 }

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -41,7 +41,7 @@ public sealed class SuitSensorSystem : SharedSuitSensorSystem
             if (!CheckSensorAssignedStation((uid, sensor)))
                 continue;
 
-            sensor.NextUpdate += sensor.UpdateRate;
+            //sensor.NextUpdate += sensor.UpdateRate; //Sunrise-Edit
 
             // get sensor status
             var status = GetSensorState((uid, sensor));
@@ -56,6 +56,8 @@ public sealed class SuitSensorSystem : SharedSuitSensorSystem
 
                 sensor.ConnectedServer = address;
             }
+
+            sensor.NextUpdate += sensor.UpdateRate; //Sunrise-Edit
 
             // Send it to the connected server
             var payload = SuitSensorToPacket(status);

--- a/Content.Shared/Atmos/Consoles/Components/AtmosAlertsComputerComponent.cs
+++ b/Content.Shared/Atmos/Consoles/Components/AtmosAlertsComputerComponent.cs
@@ -38,6 +38,9 @@ public sealed partial class AtmosAlertsComputerComponent : Component
 
     [DataField]
     public TimeSpan NextBeep = TimeSpan.Zero;
+
+    [DataField]
+    public bool DoAtmosAlert = true;
     // Sunrise-end
 }
 

--- a/Content.Shared/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
+++ b/Content.Shared/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
@@ -1,14 +1,14 @@
-using Content.Shared.Audio;
+using Content.Shared.Audio;//Sunrise-Edit
 using Content.Shared.Medical.SuitSensor;
-using Content.Shared.Medical.CrewMonitoring;
+using Content.Shared.Medical.CrewMonitoring;//Sunrise-Edit
 using Robust.Shared.Audio;
+using Content.Shared._Sunrise.Medical;//Sunrise-Edit
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-using Content.Shared._Sunrise.Medical;
 
 namespace Content.Server.Medical.CrewMonitoring;
 
 [RegisterComponent]
-[Access(typeof(SharedCrewMonitoringConsoleSystem))]
+[Access(typeof(SharedCrewMonitoringConsoleSystem))]//Sunrise-Edit
 public sealed partial class CrewMonitoringConsoleComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
+++ b/Content.Shared/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
@@ -1,11 +1,14 @@
+using Content.Shared.Audio;
 using Content.Shared.Medical.SuitSensor;
+using Content.Shared.Medical.CrewMonitoring;
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared._Sunrise.Medical;
 
 namespace Content.Server.Medical.CrewMonitoring;
 
 [RegisterComponent]
-[Access(typeof(CrewMonitoringConsoleSystem))]
+[Access(typeof(SharedCrewMonitoringConsoleSystem))]
 public sealed partial class CrewMonitoringConsoleComponent : Component
 {
     /// <summary>
@@ -22,8 +25,8 @@ public sealed partial class CrewMonitoringConsoleComponent : Component
     /// <summary>
     ///     Whether the console should beep when corpses with sensors are detected outside morgues.
     /// </summary>
-    [DataField("doCorpseAlert"), ViewVariables(VVAccess.ReadWrite)]
-    public bool DoCorpseAlert = true;
+    [DataField("CrewMonitoringMode"), ViewVariables(VVAccess.ReadWrite)]
+    public CrewMonitoringMode Mode = CrewMonitoringMode.ToggleOff;
 
     /// <summary>
     ///     Next time to check for corpses and potentially play alert sound.
@@ -41,5 +44,5 @@ public sealed partial class CrewMonitoringConsoleComponent : Component
     ///     Sound to play when corpses with sensors are detected outside morgues.
     /// </summary>
     [DataField("corpseAlertSound")]
-    public SoundSpecifier CorpseAlertSound = new SoundPathSpecifier("/Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg");
+    public SoundSpecifier CorpseAlertSound = new SoundPathSpecifier("/Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg", AudioParams.Default.WithVariation(SharedContentAudioSystem.DefaultVariation).WithVolume(-3f));
 }

--- a/Content.Shared/Medical/CrewMonitoring/CrewMonitoringShared.cs
+++ b/Content.Shared/Medical/CrewMonitoring/CrewMonitoringShared.cs
@@ -8,7 +8,7 @@ public enum CrewMonitoringUIKey
 {
     Key
 }
-
+//Sunrise-Start
 [Serializable, NetSerializable]
 public enum CrewMonitoringMode : byte
 {
@@ -32,7 +32,7 @@ public enum CrewMonitoringMode : byte
     /// </summary>
     Both = 3
 }
-
+//Sunrise-End
 [Serializable, NetSerializable]
 public sealed class CrewMonitoringState : BoundUserInterfaceState
 {

--- a/Content.Shared/Medical/CrewMonitoring/CrewMonitoringShared.cs
+++ b/Content.Shared/Medical/CrewMonitoring/CrewMonitoringShared.cs
@@ -10,6 +10,30 @@ public enum CrewMonitoringUIKey
 }
 
 [Serializable, NetSerializable]
+public enum CrewMonitoringMode : byte
+{
+    /// <summary>
+    /// Monitoring alarm is off
+    /// </summary>
+    ToggleOff = 0,
+
+    /// <summary>
+    /// Monitoring alarm is triggered when the mob's status changes with working sensors
+    /// </summary>
+    StateChanged = 1,
+
+    /// <summary>
+    /// Monitoring alarm is triggered when anyone is dead with working sensors
+    /// </summary>
+    AnyoneDead = 2,
+
+    /// <summary>
+    /// Both mode
+    /// </summary>
+    Both = 3
+}
+
+[Serializable, NetSerializable]
 public sealed class CrewMonitoringState : BoundUserInterfaceState
 {
     public List<SuitSensorStatus> Sensors;

--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Alert;
+using Content.Shared.Audio;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Systems;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -46,6 +48,9 @@ public sealed partial class MobThresholdsComponent : Component
     /// </summary>
     [DataField("allowRevives")]
     public bool AllowRevives;
+
+    [DataField]
+    public SoundSpecifier AlertSound = new SoundPathSpecifier("/Audio/_Sunrise/Items/Medical/scanner_use.ogg", AudioParams.Default.WithVariation(SharedContentAudioSystem.DefaultVariation).WithVolume(10f));
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -1,8 +1,8 @@
 using Content.Shared.Alert;
-using Content.Shared.Audio;
+using Content.Shared.Audio;//Sunrise-Edit
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Systems;
-using Robust.Shared.Audio;
+using Robust.Shared.Audio;//Sunrise-Edit
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -48,9 +48,10 @@ public sealed partial class MobThresholdsComponent : Component
     /// </summary>
     [DataField("allowRevives")]
     public bool AllowRevives;
-
+    //Sunrise-Start
     [DataField]
     public SoundSpecifier AlertSound = new SoundPathSpecifier("/Audio/_Sunrise/Items/Medical/scanner_use.ogg", AudioParams.Default.WithVariation(SharedContentAudioSystem.DefaultVariation).WithVolume(10f));
+    //Sunrise-End
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -3,14 +3,27 @@ using System.Linq;
 using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Events;
+using Content.Shared.Medical.SuitSensor;
+using Content.Shared.Medical.SuitSensors;
 using Robust.Shared.GameStates;
+using Robust.Shared.Timing; //Sunrise-Edit
+using Robust.Shared.Audio; //Sunrise-Edit
+using Robust.Shared.Audio.Systems; //Sunrise-Edit
+using Robust.Shared.Containers;
+using Content.Shared.Medical.CrewMonitoring;
+using Content.Server.Medical.CrewMonitoring;
 
 namespace Content.Shared.Mobs.Systems;
 
 public sealed class MobThresholdSystem : EntitySystem
 {
+    [Dependency] private readonly IEntityManager _entManager = default!; //Sunrise-Edit
+    [Dependency] private readonly IGameTiming _timing = default!; //Sunrise-Edit
+    [Dependency] private readonly EntityLookupSystem _lookup = default!; //Sunrise-Edit
+    [Dependency] private readonly SharedAudioSystem _audio = default!; //Sunrise-Edit
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
 
@@ -472,6 +485,99 @@ public sealed class MobThresholdSystem : EntitySystem
     private void OnThresholdsMobState(Entity<MobThresholdsComponent> ent, ref MobStateChangedEvent args)
     {
         UpdateAllEffects((ent, ent, null, null), args.NewMobState);
+
+
+        if (args.NewMobState > args.OldMobState && args.OldMobState != 0)
+            TrySendAlarmSignal(ent, args.NewMobState);
+    }
+
+    private void TrySendAlarmSignal(EntityUid ent, MobState mobState)
+    {
+        if (!_entManager.TryGetComponent<ContainerManagerComponent>(ent, out var inv))
+                return;
+        
+        
+        foreach (var (slot, container) in inv.Containers)
+        {
+
+            if (slot == "jumpsuit")
+                {
+                    if (container.ContainedEntities.Count == 0)
+                        continue;  
+
+                    var suit = container.ContainedEntities[0];
+                    
+                    if (!CanSendAlarmMessage(suit,mobState))
+                        continue;
+                    
+                    SendAlarmMessage(ent);
+                    return;
+                }
+            if (slot == "implant")
+                {
+                    if (container.ContainedEntities.Count == 0)
+                        continue;  
+                    
+                    var implants = container.ContainedEntities;
+
+                    foreach (var implant in implants)
+                    {
+                        if (!CanSendAlarmMessage(implant,mobState))
+                        continue;
+
+                        SendAlarmMessage(ent);
+                        return;
+                    }
+                }
+            
+        }
+
+    }
+
+    private bool CanSendAlarmMessage(EntityUid ent, MobState mobState)
+    {
+        if (!_entManager.TryGetComponent<SuitSensorComponent>(ent, out var sensor))
+            return false;
+
+        if (sensor.ConnectedServer == null)
+            return false;
+
+        if (sensor.NextUpdate < _timing.CurTime - TimeSpan.FromSeconds(4))
+            return false;
+
+        if (sensor.Mode == SuitSensorMode.SensorOff)
+            return false;
+                        
+        if (sensor.Mode == SuitSensorMode.SensorBinary   && mobState == MobState.Critical)
+            return false;
+        
+        return true;
+    }
+
+    private void SendAlarmMessage(EntityUid ent)
+    {
+        if (!_entManager.TryGetComponent<TransformComponent>(ent, out var transform))
+                return;
+
+        if (!_entManager.TryGetComponent<MobThresholdsComponent>(ent, out var mt))
+                return;
+            
+        if (transform.GridUid == null)
+            return;
+        var entities = new HashSet<Entity<CrewMonitoringConsoleComponent>>();
+        _lookup.GetGridEntities(transform.GridUid.Value, entities);
+        foreach (var entityUid in entities)
+        {
+
+            if (!_entManager.TryGetComponent<CrewMonitoringConsoleComponent>(entityUid, out var inter))
+                continue;
+            
+            if (inter.Mode == CrewMonitoringMode.ToggleOff || inter.Mode == CrewMonitoringMode.AnyoneDead)
+                continue;
+            
+            _audio.PlayPvs(mt.AlertSound, entityUid);
+
+        }
     }
 
     #endregion

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -1,31 +1,31 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Server.Medical.CrewMonitoring;
 using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
-using Content.Shared.Mobs;
+using Content.Shared.Medical.CrewMonitoring;
+using Content.Shared.Medical.SuitSensor;//Sunrise-Edit
+using Content.Shared.Medical.SuitSensors;//Sunrise-Edit
+using Content.Shared.Mobs;//Sunrise-Edit
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Events;
-using Content.Shared.Medical.SuitSensor;
-using Content.Shared.Medical.SuitSensors;
-using Robust.Shared.GameStates;
-using Robust.Shared.Timing; //Sunrise-Edit
 using Robust.Shared.Audio; //Sunrise-Edit
 using Robust.Shared.Audio.Systems; //Sunrise-Edit
+using Robust.Shared.Timing; //Sunrise-Edit
+using Robust.Shared.GameStates;
 using Robust.Shared.Containers;
-using Content.Shared.Medical.CrewMonitoring;
-using Content.Server.Medical.CrewMonitoring;
 
 namespace Content.Shared.Mobs.Systems;
 
 public sealed class MobThresholdSystem : EntitySystem
 {
+    [Dependency] private readonly SharedAudioSystem _audio = default!; //Sunrise-Edit
+    [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IEntityManager _entManager = default!; //Sunrise-Edit
     [Dependency] private readonly IGameTiming _timing = default!; //Sunrise-Edit
     [Dependency] private readonly EntityLookupSystem _lookup = default!; //Sunrise-Edit
-    [Dependency] private readonly SharedAudioSystem _audio = default!; //Sunrise-Edit
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-    [Dependency] private readonly AlertsSystem _alerts = default!;
 
     public override void Initialize()
     {
@@ -486,11 +486,10 @@ public sealed class MobThresholdSystem : EntitySystem
     {
         UpdateAllEffects((ent, ent, null, null), args.NewMobState);
 
-
-        if (args.NewMobState > args.OldMobState && args.OldMobState != 0)
-            TrySendAlarmSignal(ent, args.NewMobState);
+        if (args.NewMobState > args.OldMobState && args.OldMobState != 0)//Sunrise-Edit
+            TrySendAlarmSignal(ent, args.NewMobState);//Sunrise-Edit
     }
-
+    //Sunrise-Start
     private void TrySendAlarmSignal(EntityUid ent, MobState mobState)
     {
         if (!_entManager.TryGetComponent<ContainerManagerComponent>(ent, out var inv))
@@ -578,6 +577,7 @@ public sealed class MobThresholdSystem : EntitySystem
             _audio.PlayPvs(mt.AlertSound, entityUid);
 
         }
+        //Sunrise-End
     }
 
     #endregion

--- a/Content.Shared/Verbs/VerbCategory.cs
+++ b/Content.Shared/Verbs/VerbCategory.cs
@@ -90,5 +90,7 @@ namespace Content.Shared.Verbs
             new("verb-categories-adjust", "/Textures/Interface/VerbIcons/screwdriver.png");
 
         public static readonly VerbCategory Switch = new("verb-categories-switch", "/Textures/Interface/VerbIcons/group.svg.192dpi.png"); // Starlight-surgery
+
+        public static readonly VerbCategory SetCrewMonitoring = new("verb-categories-set-crew-monitoring", null); //Sunrise-Edit
     }
 }

--- a/Content.Shared/_Sunrise/Medical/SharedCrewMonitoringConsoleComponent.cs
+++ b/Content.Shared/_Sunrise/Medical/SharedCrewMonitoringConsoleComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._Sunrise.Medical;
+
+public abstract class SharedCrewMonitoringConsoleSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+    }
+}

--- a/Resources/Locale/en-US/_strings/_sunrise/toggle-alert/toggle-alert.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/toggle-alert/toggle-alert.ftl
@@ -1,0 +1,7 @@
+item-toggle-deactivate-alert = Deactivate alert
+item-toggle-activate-alert = Activate alert
+crew-monitoring-mode-ToggleOff = Off
+crew-monitoring-mode-StateChanged = On state change
+crew-monitoring-mode-AnyoneDead = Anyone dead
+crew-monitoring-mode-Both = Combined
+verb-categories-set-crew-monitoring = Alert

--- a/Resources/Locale/ru-RU/_strings/_sunrise/toggle-alert/toggle-alert.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/toggle-alert/toggle-alert.ftl
@@ -1,0 +1,7 @@
+item-toggle-deactivate-alert = Деактивировать тревогу
+item-toggle-activate-alert = Активировать тревогу
+crew-monitoring-mode-ToggleOff = Выкл.
+crew-monitoring-mode-StateChanged = Изменение состояния
+crew-monitoring-mode-AnyoneDead = Наличие мёртвых
+crew-monitoring-mode-Both = Комбинированная
+verb-categories-set-crew-monitoring = Тревога

--- a/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
@@ -7,6 +7,6 @@
   - type: ItemToggle
     onUse: false # above component does the toggling
   - type: PowerCellDraw
-    drawRate: 0
+    drawRate: 2 #Sunrise-Edit
     useRate: 20
   - type: ToggleCellDraw


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
- Добавлен режим пищания для мониторингов экипажа при смене состояния здоровья на критическое/смерть
- Добавлена возможность переключения или отключения режимов сигнализации мониторингов
- Добавлена возможность отключить сигнализацию атмосферного мониторинга
- Уменьшена громкость пищалки мониторинга экипажа
- Теперь мониторинги тратят энергию при их использовании(а не только при открытии)
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Сначала хотел просто отключить пищалку, как делал ранее в #3079, но подумал что было бы неплохо ещё доработать.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

https://github.com/user-attachments/assets/852f0b75-7c78-45a4-ad26-0e276f2231e5


**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
