### PR TITLE
изменение скафов ИО

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -30,6 +30,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
+        Shock: 0.6 #Sunrise-edit 
         Heat: 0.8
         Radiation: 0.5
   - type: ClothingSpeedModifier
@@ -423,6 +424,7 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.8
+        Shock: 0.2 #Sunrise-edit
         Heat: 0.4
         Radiation: 0.0
         Caustic: 0.7

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -252,15 +252,32 @@
   name: senior's engineer hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has radiation shielding. Very compact.
   components:
-  - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
-  - type: Sprite
-    sprite: _Sunrise/Clothing/OuterClothing/Hardsuits/engineering-compact.rsi
-  - type: Clothing
-    sprite: _Sunrise/Clothing/OuterClothing/Hardsuits/engineering-compact.rsi
-  - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitEngineeringCompact
+  # Sunrise-Start
+   - type: FireProtection
+     reduction: 0.8
+   - type: ExplosionResistance
+     damageCoefficient: 0.4
+   - type: Pierceable
+     level: Metal
+   - type: Armor
+     modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Shock: 0.5
+        Heat: 0.7
+        Radiation: 0.4
+    # Sunrise-End
+   - type: ClothingSpeedModifier
+     walkModifier: 0.85
+     sprintModifier: 0.85
+   - type: Sprite
+     sprite: _Sunrise/Clothing/OuterClothing/Hardsuits/engineering-compact.rsi
+   - type: Clothing
+     sprite: _Sunrise/Clothing/OuterClothing/Hardsuits/engineering-compact.rsi
+   - type: ToggleableClothing
+     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringCompact
 
 #Для ивентов
 


### PR DESCRIPTION

## Кратное описание
Добавил резисты к "электрическому" урону, скафам ИО  у которых по какой то причине его не было, так же изменил скафандер ВУ, ибо по какой то причине он просто наследовался от скафа инженера(все остальные риги в ИО, от базовых скафандров)
и имел микростаты.
## По какой причине
Просили


**Changelog**
:cl: Dextor
- add: Добавлена защита от электрического урона скафандрам ИО
- tweak: Изменены характеристики скафандра ВИ
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Добавлена защита от электрического удара для скафандров: атмосферного техника (коэффициент 0.6) и белого инженерного (начальника инженеров) (коэффициент 0.2).
  - Компактный инженерный скафандр усилен: повышена огнестойкость, снижён урон от взрывов, добавлена устойчивость к проколам, улучшены коэффициенты брони (удары, порезы, прокол, электрический шок, тепло, радиация).
  - Изменения улучшают выживаемость в опасных условиях без влияния на другие характеристики экипировки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->