### PR TITLE
Ребаланс гипоспреев.

### DIFF
--- a/Content.Shared/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Shared/Chemistry/Components/HyposprayComponent.cs
@@ -1,6 +1,7 @@
 // The code responsible for DoAfter was taken from the rejected Wizden PR 30704. And the code for toxin filtration is from 29879.
 using Content.Shared.DoAfter; // Sunrise-Edit
 using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set; // Sunrise-Edit
 using Robust.Shared.GameStates;
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization;
@@ -57,10 +58,10 @@ public sealed partial class HyposprayComponent : Component
     // Sunrise-Start
 
     /// <summary>
-    /// Whether or not this hypospray will destroy poisons when drawing from a container.
+    /// Reagents that cannot be injected into the hypospray. Specified in yaml.
     /// </summary>
-    [DataField]
-    public bool FilterPoison = false;
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public HashSet<string> FilterReagentGroups = new();
 
     /// <summary>
     ///  If set over 0, enables a doafter for the hypospray which must be completed for injection.

--- a/Content.Shared/Chemistry/EntitySystems/HypospraySystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/HypospraySystem.cs
@@ -37,8 +37,6 @@ public sealed class HypospraySystem : EntitySystem
     // Sunrise-Start
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-
-    private const string MedicineReagentGroup = "Medicine";
     // Sunrise-End
 
     public override void Initialize()
@@ -61,7 +59,7 @@ public sealed class HypospraySystem : EntitySystem
         args.Handled = TryDoInject(entity, args.Args.Target.Value, args.Args.User);
     }
 
-    private bool HasInvalidReagents(Solution solution, string group, IPrototypeManager prototypeManager)
+    private bool HasInvalidReagents(Solution solution, HashSet<string> allowedGroups, IPrototypeManager prototypeManager)
     {
         foreach (var (reagent, _) in solution.Contents)
         {
@@ -71,10 +69,8 @@ public sealed class HypospraySystem : EntitySystem
                 continue;
             }
 
-            if (reagentProto.Group != group)
-            {
+            if (!allowedGroups.Contains(reagentProto.Group))
                 return true;
-            }
         }
 
         return false;
@@ -274,9 +270,9 @@ public sealed class HypospraySystem : EntitySystem
         }
 
         // Sunrise-Start
-        if (entity.Comp.FilterPoison)
+        if (entity.Comp.FilterReagentGroups.Count > 0)
         {
-            var hasInvalidReagents = HasInvalidReagents(targetSolution.Comp.Solution, MedicineReagentGroup, _prototypeManager);
+            var hasInvalidReagents = HasInvalidReagents(targetSolution.Comp.Solution, entity.Comp.FilterReagentGroups, _prototypeManager);
             if (hasInvalidReagents)
             {
                 _popup.PopupEntity(Loc.GetString("hypospray-invalid-reagents-message",

--- a/Resources/Locale/ru-RU/_strings/_sunrise/chemistry/components/hypospray-component.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/chemistry/components/hypospray-component.ftl
@@ -1,0 +1,1 @@
+hypospray-invalid-reagents-message = В { $target } обнаружены несовместимые реагенты.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -769,14 +769,6 @@
     Telecrystal: 6
   categories:
   - UplinkChemicals
-  # Sunrise-Start
-  conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - SubdermalImplant
-      - NukeOpsUplink
-  # Sunrise-End
 
 - type: listing
   id: UplinkHypoDart

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -661,8 +661,6 @@
     solutions:
       hypospray:
         maxVol: 10
-  - type: RefillableSolution
-    solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
     filterReagentGroups: # Sunrise-Edit

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -665,6 +665,9 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    filterReagentGroups: # Sunrise-Edit
+     - Toxins
+     - Narcotics
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
@@ -887,7 +887,6 @@
   id: UplinkHypo
   name: uplink-hypo-name
   description: uplink-hypo-desc
-  icon: { sprite: /Textures/Objects/Specific/Medical/syndihypo.rsi, state: hypo }
   productEntity: SyndiHypo
   discountCategory: rareDiscounts
   discountDownTo:
@@ -897,10 +896,8 @@
   categories:
   - UplinkChemicals
   conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - AssaultOpsUplink
+  - !type:ListingLimitedStockCondition
+    stock: 2
 
 - type: listing
   id: UplinkSyndicateRapier

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Medical/hypospray.yml
@@ -96,8 +96,9 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    filterReagentGroups:
+     - Medicine
     onlyAffectsMobs: true
-    filterPoison: true
     doAfterTime: 0.75
     transferAmount: 5
   - type: UseDelay


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Добавлена покупка горлекс гипоспрея абсолютно всем, а не только ДО.
Гипоручка теперь имеет фильтр на реагенты: Яды, наркотики.
Гипоручка была возращена ядерным оперативникам.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Ядерные оперативники начали сосать.
Теперь невозможно исцелиться за 5 секунд без последствий (истощение и ребаланс визардов)
Так как теперь гипоручка имеет вайтлист, я решил добавить возможность покупки горлекс гипоспрея за вдвое большую цену 

## Технические детали
Теперь можно устанавливать вайтлист реагентов гипоспрею прямо в прототипе.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: banumbas
- tweak: Гипоручка теперь имеет вайтлист на группы реагентов: Яды и токсины.
- tweak: Гипоручка возращена ядерным оперативникам.
- tweak: Теперь гипоспрей горлекса доступен ядерным оперативникам и агентам.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Новые функции
  - Гипоспреи теперь поддерживают фильтрацию по нескольким группам реагентов.
  - Гипопен: загрузка ограничена группами «Toxins» и «Narcotics», воспроизводит звук при использовании и больше не перезаряжается.
  - Медицинский гипоспрей ограничен группой «Medicine».
- Документация
  - Добавлено русское сообщение о несовместимых реагентах при инъекции.
- Chores
  - Убрано старое условие доступа для UplinkHypopen; UplinkHypo и UplinkSyndicateRapier получили ограничение наличия (stock: 2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->