### PR TITLE
Мелкие изменения в меде

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -310,6 +310,7 @@ public sealed partial class MechSystem : SharedMechSystem
         if (args.DamageDelta != null && component.PilotSlot.ContainedEntity != null && args.DamageIncreased)
         {
             var damageToPlayer = args.DamageDelta * component.MechToPilotDamageMultiplier;
+            damageToPlayer.DamageDict.Remove("Mangleness");//Sunrise-Edit
             _damageable.TryChangeDamage(component.PilotSlot.ContainedEntity, damageToPlayer);
         }
     }

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -11,6 +11,8 @@
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
     HyposprayMedical: 2 # Sunrise-Edit
+    Dropper: 2 # Sunrise-Edit
+    BaseChemistryEmptyVial: 2 # Sunrise-Edit
     PatchPack: 4 # Sunrise-Edit
     PatchMedical: 5 # Sunrise-Edit
     PatchBrute: 5 # Sunrise-Edit

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -273,11 +273,11 @@
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 30 #Sunrise-Edit
     damage:
       types:
         Heat: -0.07
-        Mangleness: -0.01 #SUNRISE-EDIT
+        Mangleness: -0.02 #SUNRISE-EDIT
       groups:
         Brute: -0.07
   - type: Fingerprint

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -33,7 +33,7 @@
         Brute: -0.5
       #Sunrise-Start
       types: 
-        Mangleness: -0.02
+        Mangleness: -0.03
       #Sunrise-End
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -73,7 +73,7 @@
     damage:
       types:
         Heat: -0.14
-        Mangleness: -0.02 #Sunrise-Edit
+        Mangleness: -0.03 #Sunrise-Edit
       groups:
         Brute: -0.14
   - type: DamageVisuals

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -42,11 +42,12 @@
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 30 #Sunrise-Edit
     damage:
       types:
         Heat: -0.07
         Poison: -0.2 # needs to be less than the PendingZombieComponent does or they never become zombies by the disease.
+        Mangleness: -0.02 #Sunrise-Edit
       groups:
         Brute: -0.07
   - type: DamageVisuals

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -22,7 +22,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.45,-0.45,0.45,0.05"
-        density: 190
+        density: 1900 #SUNRISE-EDIT
         mask:
         - TableMask
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -69,6 +69,7 @@
     anchored: true
     noRot: true
   - type: Anchorable
+    delay: 5 #SUNRISE-EDIT
   - type: Pullable
   - type: CanSleepOnBuckle # Sunrise-Edit
 

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -81,7 +81,7 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 20
+          min: 20.5
         damage:
           types:
             Poison: 2 # this is added to the base damage of the meth.

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Consumable/Food/candy.yml
@@ -10,9 +10,9 @@
         maxVol: 30
         reagents:
         - ReagentId: Sugar
-          Quantity: 6
+          Quantity: 3
         - ReagentId: Nutriment
-          Quantity: 6
+          Quantity: 9
         - ReagentId: Saline
           Quantity: 3
         - ReagentId: Vitamin
@@ -35,14 +35,14 @@
         maxVol: 30
         reagents:
         - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: Dermaline
+          Quantity: 6
+        - ReagentId: Vitamin
           Quantity: 9
         - ReagentId: Saline
-          Quantity: 6
-        - ReagentId: TranexamicAcid 
-          Quantity: 3 
-        - ReagentId: Dylovene
+          Quantity: 3
+        - ReagentId: HemostaticPowder 
+          Quantity: 3
+        - ReagentId: Omnizine
           Quantity: 9
   - type: Sprite
     sprite: _Sunrise/Objects/Consumable/Food/candy.rsi


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
- Баг фикс нанесения урона пилоту механоида при лечении меха
- Увеличение естественного восстановления истощения
- Ребаланс леденцов и жвачки мед борга
- Добавлены пипетки и пробирки в наномед
- Изменено наполнения пластыря омнизина
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Ради баланса вселенной. Истощение душит всех подряд и игроки банально забивают на его лечение, это не изменить, потому чтобы они не так душились поднял естественный реген. Ребаланс леденцов сделан с надеждой на то что их начнут использовать и чтобы жвачка не наносила урон истощением(всё равно никто омнизин не извлекает из них). Пипетки и пробирки добавлены с расчётом на то что врачи будут использовать их для более точных дозировок лекарств для предотвращения излишнего истощения(так же шприцы теперь могут перемещать по 1 юниту, но по своему опыту скажу что пипеткой удобнее)
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
