### PR TITLE
энергощищ

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -620,10 +620,11 @@
       autoRechargePause: true
       autoRechargePauseTime: 5
     - type: EnergyShield
+      energyCostPerDamage: 15
     - type: ExaminableBattery
     - type: Battery
-      maxCharge: 2500
-      startingCharge: 2500
+      maxCharge: 1500
+      startingCharge: 1500
     - type: PowerCellDraw
       useRate: 2.5
     # Sunrise-End

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -622,8 +622,8 @@
     - type: EnergyShield
     - type: ExaminableBattery
     - type: Battery
-      maxCharge: 1500
-      startingCharge: 1500
+      maxCharge: 2500
+      startingCharge: 2500
     - type: PowerCellDraw
       useRate: 2.5
     # Sunrise-End


### PR DESCRIPTION
## Кратное описание
бафф прочности энергощита

## По какой причине
недавно энергощит получил приятный бафф, а именно самозарядку(22 секунды с 0 до 100), а так же снижение цены, но возникла другая проблема, щит не держит урон от слова совсем он заканчивается в файте за секунду из за чего становится буквально бесполезным, а так жеф все его функции выполняет даже лучше противолазерный щит, который имеет в 2 раза больше прочность, защищает так же, а рефлект всего лишь ниже на 15 процентов.
Исходя из этого, щит все еще не имеет смысла единственное его преимущество - это возможность его чинить путем автоматической зарядки, но и это потеряет смысл, ибо скоро будет введена система, которая будет позволять восстанавливать прочность щитов
Ну и главная причина - щит ни кто не берет, ни до обновы ни после


Исходя из этого я предлагаю два варианта:
1 - просто баффнуть ему прочность.
2 - баффнуть прочность еще сильней, но сделать так, чтобы зарядка была долгой
3 - забить на него хуй - пусть и дальше не берут

первый вариант я реализовал в этом ПРе

(статистика по щитам)
.20 патроны
противолазерный SP = 18
противолазерный FMJ = 22

энерго SP = 10
энерго FMJ = 12

энерго(бафф) SP = 17
энерго FMJ(бафф) = 24



## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: Dextor
- tweak: энергощиту была увлечена прочность.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Баланс**
  * Энергетический щит теперь тратит 15 единиц энергии за единицу получаемого урона — заметно влияет на скорость расхода заряда щита.
  * Ёмкость и начальный заряд батарей не изменялись; длительность работы в конкретных сценариях скорректируется за счёт повышенного расхода.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->