### PR TITLE
Упростил рецепт щита

### DIFF
--- a/Resources/Prototypes/_Sunrise/Recipes/Construction/Graphs/weapons/strobeshield.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Construction/Graphs/weapons/strobeshield.yml
@@ -18,10 +18,6 @@
           state: flash
       - material: Cable
         amount: 2
-      - material: Steel
-        amount: 1
-      - material: Manipulator
-        amount: 1
         doAfter: 5
   - node: shieldstrobe
     entity: RiotShieldStrobe


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Упростил рецепт щита

## По какой причине
Рецепт был слишком геморным и не стоил потраченного времени на крафт

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
:cl: Kinar_7
- tweak: Рецепт создания щита со стробоскопом был упрощен




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Баланс
  - Упрощён рецепт изготовления стробо-щита: больше не требуются сталь и манипулятор.
  - Требование по кабелю (2) сохранено; время сборки — 5 секунд без изменений.
  - Крафт стал дешевле и быстрее, повысив доступность предмета на ранних этапах.
  - Остальная логика и последовательность шагов рецепта не изменены.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->