### PR TITLE
Уменьшение защиты от взрыва для НРа и Си а так же рад защиты

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -414,7 +414,7 @@
   - type: FireProtection
     reduction: 0.8
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.4 # Sunrise-edit
   - type: Pierceable
     level: Metal
   - type: Armor
@@ -424,7 +424,7 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.4
-        Radiation: 0.0
+        Radiation: 0.1 # Sunrise-edit
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -495,10 +495,10 @@
         Slash: 0.8
         Piercing: 0.9
         Heat: 0.3
-        Radiation: 0.1
+        Radiation: 0.2 # Sunrise-edit
         Caustic: 0.2
   - type: ExplosionResistance
-    damageCoefficient: 0.1
+    damageCoefficient: 0.3 # Sunrise-edit
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -790,7 +790,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.3
   - type: StaminaResistance # Should not have stamina resistance, this is purely so people know it was not forgotten.
-    damageCoefficient: 0.1 #Sunrise-edit
+    damageCoefficient: 0.4 #Sunrise-edit
   - type: Pierceable
     level: Rock
   - type: Armor

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -21,7 +21,7 @@
         Piercing: 0.9
         Heat: 0.75
   - type: ExplosionResistance
-    damageCoefficient: 0.15
+    damageCoefficient: 0.3 # Sunrise-edit
   - type: GroupExamine
   - type: Tag
     tags:


### PR DESCRIPTION
Increased explosion and radiation resistance coefficients for several hardsuits and suits to improve survivability. These changes are marked as Sunrise-edits and affect both armor and resistance values.


## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

# Шахиды ненормальные
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: Изменены показатели взрыво защиты у скафандра НРа и СИ.
- tweak: Изменено показатель рад  защиты у скафандра НРа и СИ.