### PR TITLE
Loadout item duplication fix

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -37,7 +37,6 @@
   job: MedicalDoctor
   equipment:
     head: ClothingHeadNurseHat
-    eyes: ClothingEyesHudMedical
     mask: ClothingMaskSterile
     neck: ClothingNeckStethoscope
     outerClothing: ClothingOuterCoatLab

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Science/roboticist.yml
@@ -22,7 +22,6 @@
 - type: startingGear
   id: RoboticistGear
   equipment:
-    outerClothing: ClothingOuterCoatRobo
     id: RoboticistPDA
     gloves: ClothingHandsGlovesRobohands
     head: ClothingHeadHatWelding


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Теперь некоторые элементы одежды не будут дублироваться и выпадать на пол при спавне. 

## По какой причине
Баг

**Changelog**
:cl: Hero_010
- fix: Исправлено дублирование элементов одежды при спавне.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Геймплей**
  * Хамелеон-набор врача больше не включает медицинский глазной HUD; слот глаз не выдается. Это снижает скрытую информативность и делает внешний вид более нейтральным, прочие предметы набора без изменений.
  * Стартовый набор робототехника больше не содержит предмета внешней одежды. Это уменьшает стартовую защиту/маскировку и упрощает экипировку; остальные слоты (PDA, перчатки, голова, глаза, пояс, уши, карманы) остаются без изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->