### PR TITLE
Alcohol encoding mechanics

### DIFF
--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -28,7 +28,7 @@ public sealed partial class PsychologistSystem : EntitySystem
         SubscribeLocalEvent<HumanoidAppearanceComponent, AlcoholBlockEvent>(OnAlcoholBlockTry);
         SubscribeLocalEvent<HumanoidAppearanceComponent, DoAfterAlcoholBlockEvent>(DoAfterAlcoholBlock);
 
-        SubscribeLocalEvent<BlockAlcoholComponent, BeforeIngestedEvent>(OnDrink);
+        SubscribeLocalEvent<SolutionIngestBlockerComponent, BeforeIngestedEvent>(OnDrink);
     }
 
     private void DoAfterAlcoholBlock(Entity<HumanoidAppearanceComponent> ent, ref DoAfterAlcoholBlockEvent args)
@@ -37,15 +37,15 @@ public sealed partial class PsychologistSystem : EntitySystem
             return;
         if (args.Target != null)
         {
-            if (CompOrNull<BlockAlcoholComponent>(args.Target) != null)
+            if (CompOrNull<SolutionIngestBlockerComponent>(args.Target) != null)
             {
                 _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-removed", ("target", args.Target)), ent.Owner);
-                RemComp<BlockAlcoholComponent>(args.Target.Value);
+                RemComp<SolutionIngestBlockerComponent>(args.Target.Value);
             }
             else
             {
                 _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-applied", ("target", args.Target)), ent.Owner);
-                AddComp<BlockAlcoholComponent>(args.Target.Value);
+                AddComp<SolutionIngestBlockerComponent>(args.Target.Value);
             }
         }
     }
@@ -79,13 +79,13 @@ public sealed partial class PsychologistSystem : EntitySystem
         }
 
     }
-    private void OnDrink(Entity<BlockAlcoholComponent> ent, ref BeforeIngestedEvent args)
+    private void OnDrink(Entity<SolutionIngestBlockerComponent> ent, ref BeforeIngestedEvent args)
     {
         if (args.Solution != null)
         {
             foreach (var cont in args.Solution.Contents)
             {
-                if (cont.Reagent.ToString() == "Ethanol")
+                if (cont.Reagent.ToString() == ent.Comp.ReagentForBlock)
                 {
                     args.Cancelled = true;
                     return;
@@ -98,7 +98,7 @@ public sealed partial class PsychologistSystem : EntitySystem
                     {
                         foreach (var effect in metabolism.Value.Effects)
                         {
-                            if (effect is AdjustReagent adjust && adjust.Reagent == "Ethanol")
+                            if (effect is AdjustReagent adjust && adjust.Reagent != null && adjust.Reagent == ent.Comp.ReagentForBlock)
                             {
                                 args.Cancelled = true;
                                 return;

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -1,56 +1,107 @@
 using Content.Shared.Humanoid;
 using Content.Shared.DoAfter;
 using Content.Shared.Nutrition;
+using Robust.Shared.Prototypes;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityEffects.Effects;
+using Content.Shared.Popups;
+
 namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
 
 public sealed partial class PsychologistSystem : EntitySystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<HumanoidAppearanceComponent, AlcoholBlockEvent>(onAlcoholBlockTry);
+        SubscribeLocalEvent<HumanoidAppearanceComponent, AlcoholBlockEvent>(OnAlcoholBlockTry);
         SubscribeLocalEvent<HumanoidAppearanceComponent, DoAfterAlcoholBlockEvent>(DoAfterAlcoholBlock);
 
-        SubscribeLocalEvent<AlcoholBlockComponent, BeforeIngestedEvent>(OnDrink);
+        SubscribeLocalEvent<BlockAlcoholComponent, BeforeIngestedEvent>(OnDrink);
     }
 
     private void DoAfterAlcoholBlock(Entity<HumanoidAppearanceComponent> ent, ref DoAfterAlcoholBlockEvent args)
     {
         if (args.Target != null)
         {
-            if (CompOrNull<AlcoholBlockComponent>(args.Target) != null)
+            if (CompOrNull<BlockAlcoholComponent>(args.Target) != null)
             {
-                RemComp<AlcoholBlockComponent>(args.Target.Value);
-                args.Handled = true;
+                RemComp<BlockAlcoholComponent>(args.Target.Value);
             }
             else
             {
-                AddComp<AlcoholBlockComponent>(args.Target.Value);
-                args.Handled = true;
+                AddComp<BlockAlcoholComponent>(args.Target.Value);
+            }
+        }
+    }
+
+    private void OnAlcoholBlockTry(Entity<HumanoidAppearanceComponent> ent, ref AlcoholBlockEvent args)
+    {
+        if (EntityManager.TryGetComponent<HumanoidAppearanceComponent>(args.Target, out var humanoidAppearanceComponent))
+        {
+            if (humanoidAppearanceComponent != null)
+            {
+                if ($"{humanoidAppearanceComponent.Species.Id}" == "Dwarf")
+                {
+                    _popupSystem.PopupEntity("You cant encode Dwarf", ent.Owner);
+                    return;
+                }
+            }
+        }
+
+        if (_doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, args.Action.Comp.UseDelay ?? TimeSpan.FromSeconds(10),
+            new DoAfterAlcoholBlockEvent(), eventTarget: args.Target, target: args.Target, used: args.Target)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true
+        }))
+        {
+            args.Handled = true;
+        }
+        else
+        {
+            args.Handled = false;
+        }
+
+    }
+    private void OnDrink(Entity<BlockAlcoholComponent> ent, ref BeforeIngestedEvent args)
+    {
+        if (args.Solution != null)
+        {
+            foreach (var cont in args.Solution.Contents)
+            {
+                var reagent = _prototypeManager.Index<ReagentPrototype>($"{cont.Reagent}");
+
+                if (reagent.Metabolisms != null)
+                {
+                    foreach (var metabolism in reagent.Metabolisms)
+                    {
+                        foreach (var effect in metabolism.Value.Effects)
+                        {
+                            if (effect is AdjustReagent adjust && adjust.Reagent == "Ethanol")
+                            {
+                                args.Cancelled = true;
+                                return;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    return;
+                }
             }
         }
         else
         {
             return;
         }
-    }
 
-    private void onAlcoholBlockTry(Entity<HumanoidAppearanceComponent> ent, ref AlcoholBlockEvent args)
-    {
-        var tryAlcoholBlock = _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, args.Action.Comp.UseDelay ?? TimeSpan.FromSeconds(10),
-            new DoAfterAlcoholBlockEvent(), eventTarget: args.Target, target: args.Target, used: args.Target)
-        {
-            BreakOnMove = true,
-            BreakOnDamage = true
-        });
-        if (!tryAlcoholBlock)
-        {
-            args.Handled = true;
-        }
-    }
-    private void OnDrink(Entity<AlcoholBlockComponent> ent, ref BeforeIngestedEvent args)
-    {
     }
 }

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -65,7 +65,7 @@ public sealed partial class PsychologistSystem : EntitySystem
         }
 
         if (_doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, args.Action.Comp.UseDelay ?? TimeSpan.FromSeconds(30),
-            new DoAfterAlcoholBlockEvent(), eventTarget: args.Target, target: args.Target, used: args.Target)
+            new DoAfterAlcoholBlockEvent(), eventTarget: args.Target, target: args.Target, used: ent.Owner)
         {
             BreakOnMove = true,
             BreakOnDamage = true

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Prototypes;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.EntityEffects.Effects;
 using Content.Shared.Popups;
+using Content.Shared.Actions;
 
 namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
 
@@ -16,9 +17,12 @@ public sealed partial class PsychologistSystem : EntitySystem
 
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
 
+    [Dependency] private readonly SharedActionsSystem _actionsSystem  = default!;
+
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<PsychologistBlockAlcoholComponent, ComponentStartup>(onPsychologistBlockAlcohol);
 
         SubscribeLocalEvent<HumanoidAppearanceComponent, AlcoholBlockEvent>(OnAlcoholBlockTry);
         SubscribeLocalEvent<HumanoidAppearanceComponent, DoAfterAlcoholBlockEvent>(DoAfterAlcoholBlock);
@@ -102,6 +106,10 @@ public sealed partial class PsychologistSystem : EntitySystem
         {
             return;
         }
-
     }
+    private void onPsychologistBlockAlcohol(Entity<PsychologistBlockAlcoholComponent> ent, ref ComponentStartup args)
+    {
+        _actionsSystem.AddAction(ent.Owner, "PsychologistAlcoholBlock");
+    }
+
 }

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Humanoid;
+using Content.Shared.DoAfter;
+using Content.Shared.Nutrition;
+namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
+
+public sealed partial class PsychologistSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HumanoidAppearanceComponent, AlcoholBlockEvent>(onAlcoholBlockTry);
+        SubscribeLocalEvent<HumanoidAppearanceComponent, DoAfterAlcoholBlockEvent>(DoAfterAlcoholBlock);
+
+        SubscribeLocalEvent<AlcoholBlockComponent, BeforeIngestedEvent>(OnDrink);
+    }
+
+    private void DoAfterAlcoholBlock(Entity<HumanoidAppearanceComponent> ent, ref DoAfterAlcoholBlockEvent args)
+    {
+        if (args.Target != null)
+        {
+            if (CompOrNull<AlcoholBlockComponent>(args.Target) != null)
+            {
+                RemComp<AlcoholBlockComponent>(args.Target.Value);
+                args.Handled = true;
+            }
+            else
+            {
+                AddComp<AlcoholBlockComponent>(args.Target.Value);
+                args.Handled = true;
+            }
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    private void onAlcoholBlockTry(Entity<HumanoidAppearanceComponent> ent, ref AlcoholBlockEvent args)
+    {
+        var tryAlcoholBlock = _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, args.Action.Comp.UseDelay ?? TimeSpan.FromSeconds(10),
+            new DoAfterAlcoholBlockEvent(), eventTarget: args.Target, target: args.Target, used: args.Target)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true
+        });
+        if (!tryAlcoholBlock)
+        {
+            args.Handled = true;
+        }
+    }
+    private void OnDrink(Entity<AlcoholBlockComponent> ent, ref BeforeIngestedEvent args)
+    {
+    }
+}

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -32,6 +32,8 @@ public sealed partial class PsychologistSystem : EntitySystem
 
     private void DoAfterAlcoholBlock(Entity<HumanoidAppearanceComponent> ent, ref DoAfterAlcoholBlockEvent args)
     {
+        if (args.Handled || args.Cancelled)
+            return;
         if (args.Target != null)
         {
             if (CompOrNull<BlockAlcoholComponent>(args.Target) != null)

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -39,12 +39,12 @@ public sealed partial class PsychologistSystem : EntitySystem
         {
             if (CompOrNull<BlockAlcoholComponent>(args.Target) != null)
             {
-                _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-applied "), args.Target.Value);
+                _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-removed", ("target", args.Target)), ent.Owner);
                 RemComp<BlockAlcoholComponent>(args.Target.Value);
             }
             else
             {
-                _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-removed "), args.Target.Value);
+                _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-applied", ("target", args.Target)), ent.Owner);
                 AddComp<BlockAlcoholComponent>(args.Target.Value);
             }
         }

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistAbilities.cs
@@ -6,6 +6,7 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.EntityEffects.Effects;
 using Content.Shared.Popups;
 using Content.Shared.Actions;
+using Robust.Shared.Localization;
 
 namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
 
@@ -38,10 +39,12 @@ public sealed partial class PsychologistSystem : EntitySystem
         {
             if (CompOrNull<BlockAlcoholComponent>(args.Target) != null)
             {
+                _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-applied "), args.Target.Value);
                 RemComp<BlockAlcoholComponent>(args.Target.Value);
             }
             else
             {
+                _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-removed "), args.Target.Value);
                 AddComp<BlockAlcoholComponent>(args.Target.Value);
             }
         }
@@ -53,15 +56,15 @@ public sealed partial class PsychologistSystem : EntitySystem
         {
             if (humanoidAppearanceComponent != null)
             {
-                if ($"{humanoidAppearanceComponent.Species.Id}" == "Dwarf")
+                if (humanoidAppearanceComponent.Species.Id == "Dwarf")
                 {
-                    _popupSystem.PopupEntity("You cant encode Dwarf", ent.Owner);
+                    _popupSystem.PopupEntity(Loc.GetString("psychologist-alcoholblock-dwarf-forbidden"), ent.Owner);
                     return;
                 }
             }
         }
 
-        if (_doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, args.Action.Comp.UseDelay ?? TimeSpan.FromSeconds(10),
+        if (_doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, args.Action.Comp.UseDelay ?? TimeSpan.FromSeconds(30),
             new DoAfterAlcoholBlockEvent(), eventTarget: args.Target, target: args.Target, used: args.Target)
         {
             BreakOnMove = true,
@@ -82,6 +85,11 @@ public sealed partial class PsychologistSystem : EntitySystem
         {
             foreach (var cont in args.Solution.Contents)
             {
+                if (cont.Reagent.ToString() == "Ethanol")
+                {
+                    args.Cancelled = true;
+                    return;
+                }
                 var reagent = _prototypeManager.Index<ReagentPrototype>($"{cont.Reagent}");
 
                 if (reagent.Metabolisms != null)

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class AlcoholBlockComponent : Component
+public sealed partial class BlockAlcoholComponent : Component
 {
 }
 

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
@@ -1,10 +1,14 @@
+using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class BlockAlcoholComponent : Component
+public sealed partial class SolutionIngestBlockerComponent : Component
 {
+    [DataField]
+    public ProtoId<ReagentPrototype> ReagentForBlock = "Ethanol";
 }
 
 [RegisterComponent]

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AlcoholBlockComponent : Component
+{
+}
+

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistComponents.cs
@@ -7,3 +7,7 @@ public sealed partial class BlockAlcoholComponent : Component
 {
 }
 
+[RegisterComponent]
+public sealed partial class PsychologistBlockAlcoholComponent : Component
+{
+}

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistEvents.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistEvents.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Actions;
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Sunrise.Medical.PsychologistSystem;
+
+public sealed partial class AlcoholBlockEvent : EntityTargetActionEvent
+{
+}
+
+[Serializable, NetSerializable]
+public sealed partial class DoAfterAlcoholBlockEvent : DoAfterEvent
+{
+    [DataField]
+    public TimeSpan? Duration = TimeSpan.Zero;
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistEvents.cs
+++ b/Content.Shared/_Sunrise/Medical/PsychologistSystem/PsychologistEvents.cs
@@ -11,7 +11,5 @@ public sealed partial class AlcoholBlockEvent : EntityTargetActionEvent
 [Serializable, NetSerializable]
 public sealed partial class DoAfterAlcoholBlockEvent : DoAfterEvent
 {
-    [DataField]
-    public TimeSpan? Duration = TimeSpan.Zero;
     public override DoAfterEvent Clone() => this;
 }

--- a/Resources/Locale/en-US/_strings/_sunrise/abilities/psychologist.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/abilities/psychologist.ftl
@@ -1,3 +1,3 @@
 psychologist-alcoholblock-dwarf-forbidden = You cant encode Dwarf
-psychologist-alcoholblock-applied = { $user } successful coded from Alcohol
-psychologist-alcoholblock-removed = { $user } successful decoded from Alcohol
+psychologist-alcoholblock-applied = { $target } successful coded from Alcohol
+psychologist-alcoholblock-removed = { $target } successful decoded from Alcohol

--- a/Resources/Locale/en-US/_strings/_sunrise/abilities/psychologist.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/abilities/psychologist.ftl
@@ -1,0 +1,3 @@
+psychologist-alcoholblock-dwarf-forbidden = You cant encode Dwarf
+psychologist-alcoholblock-applied = { $user } successful coded from Alcohol
+psychologist-alcoholblock-removed = { $user } successful decoded from Alcohol

--- a/Resources/Prototypes/Actions/psychologist.yml
+++ b/Resources/Prototypes/Actions/psychologist.yml
@@ -2,7 +2,7 @@
   parent: BaseAction
   id: PsychologistAlcoholBlock
   name: Alcohol coding
-  description: "Encode a person by convincing them of the evils of alcohol. Сooldown: 60 Seconds"
+  description: "Encode a person by convincing them of the evils of alcohol. Cooldown: 60 Seconds"
   categories: [ HideSpawnMenu ]
   components:
   - type: Action

--- a/Resources/Prototypes/Actions/psychologist.yml
+++ b/Resources/Prototypes/Actions/psychologist.yml
@@ -2,7 +2,7 @@
   parent: BaseAction
   id: PsychologistAlcoholBlock
   name: Alcohol coding
-  description: "Encode a person by convincing them of the evils of alcohol. СCooldown: 60 Seconds"
+  description: "Encode a person by convincing them of the evils of alcohol. Сooldown: 60 Seconds"
   categories: [ HideSpawnMenu ]
   components:
   - type: Action

--- a/Resources/Prototypes/Actions/psychologist.yml
+++ b/Resources/Prototypes/Actions/psychologist.yml
@@ -1,18 +1,24 @@
 - type: entity
   parent: BaseAction
   id: PsychologistAlcoholBlock
+  name: Alcohol coding
+  description: "Encode a person by convincing them of the evils of alcohol. СCooldown: 60 Seconds"
   categories: [ HideSpawnMenu ]
   components:
   - type: Action
-    useDelay: 5
+    useDelay: 30
     priority: 2
     itemIconStyle: NoItem
+    icon:
+      sprite: Interface/Actions/actions_ai.rsi
+      state: bolt_door
   - type: TargetAction
     range: 2
     checkCanAccess: true
-    requiresTarget: true
+  - type: LimitedCharges
+    maxCharges: 1
   - type: AutoRecharge
-    rechargeDuration: 120
+    rechargeDuration: 60
   - type: EntityTargetAction
     canTargetSelf: false
     whitelist:

--- a/Resources/Prototypes/Actions/psychologist.yml
+++ b/Resources/Prototypes/Actions/psychologist.yml
@@ -1,0 +1,21 @@
+- type: entity
+  parent: BaseAction
+  id: PsychologistAlcoholBlock
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Action
+    useDelay: 5
+    priority: 2
+    itemIconStyle: NoItem
+  - type: TargetAction
+    range: 2
+    checkCanAccess: true
+    requiresTarget: true
+  - type: AutoRecharge
+    rechargeDuration: 120
+  - type: EntityTargetAction
+    canTargetSelf: false
+    whitelist:
+      components:
+      - HumanoidAppearance
+    event: !type:AlcoholBlockEvent

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -290,6 +290,7 @@
   id: VisitorPsychologist
   parent: VisitorMedical
   components:
+    - type: PsychologistBlockAlcohol
     - type: GhostRole
       name: job-name-psychologist
     - type: Loadout

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -7,6 +7,10 @@
   icon: "JobIconPsychologist"
   supervisors: job-supervisors-cmo
   displayWeight: 10  # Sunrise
+  special:
+    - !type:AddComponentSpecial
+      components:
+      - type: PsychologistBlockAlcohol
   access:
   - Medical
   - Maintenance


### PR DESCRIPTION
## Кратное описание
Добавления возможности психологу кодировать людей от алкаголя. (Искл. дворфы)
При использовании, добавляет компонент, запрещающий пить любые вещества содержащие этанол.
Время выполнения 30 секунд и кд после попытки использования 60с. для предотвращения спама механом.
При использовании на закодированном существе убирает эффект, позволяя ему вновь пить алкаголь

## По какой причине
Добавление нового механа психологу 

## Медиа(Видео/Скриншоты)
https://github.com/user-attachments/assets/cbd33ada-7fa9-40d9-8304-d1e7cbb6a681

**Changelog**
:cl: Sidzaru
- add: Психологи получили возможность кодировать от алкаголя



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлено действие «Кодировка от алкоголя» для психолога: целевая способность с задержкой и перезарядкой, временно блокирующая употребление алкоголя у выбранного персонажа; доступно роли Психолог и гостевой роли VisitorPsychologist.
  * Процесс применения прерываемый (движением или уронами); показываются сообщения об успешном применении и снятии.

* **Локализация**
  * Добавлены строки для успешного применения, снятия и запрета для Dwarf.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->