### PR TITLE
Защита от ЭМИ для трости ПНТ и цель на Трость

### DIFF
--- a/Resources/Locale/en-US/_prototypes/_sunrise/catalog/fills/lockers/representative_nt.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/catalog/fills/lockers/representative_nt.ftl
@@ -1,0 +1,3 @@
+ent-LockerRepresentative = representative locker filled
+    .suffix = Filled
+    .desc = { ent-LockerBaseSecure.desc }

--- a/Resources/Locale/en-US/_prototypes/_sunrise/objectives/traitorObjectives.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/objectives/traitorObjectives.ftl
@@ -6,3 +6,5 @@ ent-PlutoniumCoreStealObjective = { ent-BaseTraitorStealObjective }
     .desc = { ent-BaseTraitorStealObjective.desc }
 ent-HandheldFaxStealObjective = { ent-BaseTraitorStealObjective }
     .desc = { ent-BaseTraitorStealObjective.desc }
+ent-CaneNTStealObjective = { ent-BaseTraitorStealObjective }
+    .desc = { ent-BaseTraitorStealObjective.desc }

--- a/Resources/Locale/en-US/_strings/_sunrise/objectives/steal.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/objectives/steal.ftl
@@ -1,4 +1,6 @@
 objective-condition-steal-nuclear-bomb = nuclear bomb
-objective-description-steal-supermatter-sliver = Используйте любой подходящий режущий инструмент. Лучше всего подойдёт скальпель. И постарайтесь не умереть от радиационного отравления.
+objective-description-steal-supermatter-sliver = Use any suitable cutting tool. A scalpel is best. And try not to die from radiation poisoning.
+objective-condition-steal-handheld-fax = portable fax
 objective-description-steal-handheld-fax = You need to steal a portable fax machine from a corporate representative.
-objective-condition-steal-handheld-fax = Portable fax
+objective-condition-steal-cane-nt = nanotrasen representative’s Cane
+objective-description-steal-cane-nt = You need to steal the NanoTrasen Representative’s Cane.

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/catalog/fills/lockers/representative_nt.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/catalog/fills/lockers/representative_nt.ftl
@@ -1,0 +1,3 @@
+ent-LockerRepresentativeFilled = шкаф представителя NanoTrasen
+    .suffix = Заполненный
+    .desc = { ent-LockerBaseSecure.desc }

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/objectives/traitorObjectives.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/objectives/traitorObjectives.ftl
@@ -6,3 +6,5 @@ ent-PlutoniumCoreStealObjective = { ent-BaseTraitorStealObjective }
     .desc = { ent-BaseTraitorStealObjective.desc }
 ent-HandheldFaxStealObjective = { ent-BaseTraitorStealObjective }
     .desc = { ent-BaseTraitorStealObjective.desc }
+ent-CaneNTStealObjective = { ent-BaseTraitorStealObjective }
+    .desc = { ent-BaseTraitorStealObjective.desc }

--- a/Resources/Locale/ru-RU/_strings/_sunrise/objectives/steal.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/objectives/steal.ftl
@@ -1,2 +1,6 @@
 objective-condition-steal-nuclear-bomb = ядерную бомбу
 objective-description-steal-supermatter-sliver = Используйте любой подходящий режущий инструмент. Лучше всего подойдёт скальпель. И постарайтесь не умереть от радиационного отравления.
+objective-condition-steal-handheld-fax = портативный факс
+objective-description-steal-handheld-fax = Вам нужно украсть портативный факс у представителя корпорации.
+objective-condition-steal-cane-nt = трость представителя нанотрейзен
+objective-description-steal-cane-nt = Вам нужно украсть трость у представителя корпорации.

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -27,6 +27,7 @@
     #MultiphaseEnergygunStealObjective: 1 # Sunrise-Edit: ОСЩ больше не появляется на станции
     CMOAdvancedDefibrillatorStealObjective: 1
     HandheldFaxStealObjective: 1
+    CaneNTStealObjective: 1
     # Sunrise-End
 
 - type: weightedRandom

--- a/Resources/Prototypes/_Sunrise/Catalog/Fills/Lockers/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Fills/Lockers/nanotrasenrepresentative.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: LockerRepresentativeFilled
+  name: representative locker filled
+  suffix: Filled
+  parent: LockerRepresentative
+  components:
+  - type: StorageFill
+    contents:
+      - id: CaneNT
+      - id: HandheldFax

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/cane-nt.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/cane-nt.yml
@@ -69,3 +69,4 @@
     solution: battery
   - type: DrawableSolution
     solution: battery
+  - type: EmpImmune

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/cane-nt.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/cane-nt.yml
@@ -70,3 +70,8 @@
   - type: DrawableSolution
     solution: battery
   - type: EmpImmune
+  - type: Tag
+    tags:
+    - HighRiskItem
+  - type: StealTarget
+    stealGroup: CaneNT

--- a/Resources/Prototypes/_Sunrise/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_Sunrise/Objectives/stealTargetGroups.yml
@@ -25,3 +25,10 @@
   sprite:
     sprite: _Sunrise/Objects/Devices/handled_fax.rsi
     state: icon
+
+- type: stealTargetGroup
+  id: CaneNT
+  name: objective-condition-steal-cane-nt #cane nt
+  sprite:
+    sprite: _Sunrise/Objects/Weapons/Melee/cane-nt.rsi
+    state: cane-nt

--- a/Resources/Prototypes/_Sunrise/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/_Sunrise/Objectives/traitorObjectives.yml
@@ -39,11 +39,11 @@
   components:
   - type: Objective
     difficulty: 1.5
-  - type: NotJobRequirement
-    job: NanoTrasenRepresentative
+  # - type: NotJobRequirement
+  #   job: NanoTrasenRepresentative
   - type: StealCondition
     stealGroup: HandheldFax
-    owner: job-name-ntrep
+    # owner: job-name-ntrep
 
 - type: entity
   parent: BaseTraitorStealObjective
@@ -51,8 +51,8 @@
   components:
   - type: Objective
     difficulty: 1.5
-  - type: NotJobRequirement
-    job: NanoTrasenRepresentative
+  # - type: NotJobRequirement
+  #   job: NanoTrasenRepresentative
   - type: StealCondition
     stealGroup: CaneNT
-    owner: job-name-ntrep
+    # owner: job-name-ntrep

--- a/Resources/Prototypes/_Sunrise/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/_Sunrise/Objectives/traitorObjectives.yml
@@ -44,3 +44,15 @@
   - type: StealCondition
     stealGroup: HandheldFax
     owner: job-name-ntrep
+
+- type: entity
+  parent: BaseTraitorStealObjective
+  id: CaneNTStealObjective
+  components:
+  - type: Objective
+    difficulty: 1.5
+  - type: NotJobRequirement
+    job: NanoTrasenRepresentative
+  - type: StealCondition
+    stealGroup: CaneNT
+    owner: job-name-ntrep

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -61,8 +61,8 @@
   storage:
     back:
     - RubberStampNtrep
-    - CaneNT
-    - HandheldFax #sunrise-edit
+    # - CaneNT #sunrise-edit
+    # - HandheldFax #sunrise-edit
     - RubberStampVeto #sunrise-edit
 
 - type: chameleonOutfit

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -708,6 +708,9 @@ FoodDonutJellySlugcat: FoodDonutJellyScurret
 ClothingUniformJumpsuitChiefEngineerNT: ClothingUniformJumpsuitChiefEngineer
 ClothingUniformJumpsuitParamedicNT: ClothingUniformJumpsuitParamedic
 
+# 2025-09-13
+LockerRepresentative: LockerRepresentativeFilled
+
 # Sunrise-Start
 AirlockExternalGlassShuttleArrivals: AirlockExternalGlassShuttleArrivalsLocked
 AirlockHatchSyndicate: AirlockHatchSyndicateLocked


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Вшита защита от ЭМИ в трость ПНТ в целях повышение эффективности в самозащите от нападение. Трость ПНТ станет новым Хайриском и целю для кражи у предателя. Перенос трости и портативного факса с рюкзака в шкафчик.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

Через ЭМИ трость становится разряжен, из за чего ПНТ без сопровождение ОСЩ становится беспомощным. С появлением защиты от ЭМИ, трость станет Хайриском и у предателя будет новая цель для кражи. Трость и портативный факс будут перенесены из рюкзака в шкафчик ПНТ в его кабинете, дабы предатели могли выполнить цель на кражу в случаи отсутствие ПНТ на станции.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->

:cl: VladSukr
- add: Цель на кражу трости ПНТ у предателей.
- tweak: Трость и портативный факс были перенесены в шкафчик ПНТ. Пустой шкафчик ПНТ заменен на заполненный.
- fix: Небольшое исправление локализации.
