### PR TITLE
Небольшое изменение РСУ CE.

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -568,11 +568,7 @@
         key: Pacified
         component: Pacified
         type: Add
-        time: 2
-        conditions:
-          - !type:ReagentThreshold
-            reagent: Pax
-            min: 1
+        time: 4
 
 - type: reagent
   id: Honk

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -568,7 +568,11 @@
         key: Pacified
         component: Pacified
         type: Add
-        time: 4
+        time: 2
+        conditions:
+          - !type:ReagentThreshold
+            reagent: Pax
+            min: 1
 
 - type: reagent
   id: Honk

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -563,6 +563,7 @@
   color: "#AAAAAA"
   metabolisms:
     Poison:
+      metabolismRate: 1
       effects:
       - !type:GenericStatusEffect
         key: Pacified

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -563,7 +563,6 @@
   color: "#AAAAAA"
   metabolisms:
     Poison:
-      metabolismRate: 1
       effects:
       - !type:GenericStatusEffect
         key: Pacified

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Tools/tools.yml
@@ -9,7 +9,7 @@
   - type: Clothing
     sprite: _Sunrise/Objects/Tools/advanced-rcd.rsi
   - type: AutoRecharge
-    rechargeDuration: 12.5
+    rechargeDuration: 15
 
 - type: entity
   name: abductor's wirecutter

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Tools/tools.yml
@@ -9,7 +9,7 @@
   - type: Clothing
     sprite: _Sunrise/Objects/Tools/advanced-rcd.rsi
   - type: AutoRecharge
-    rechargeDuration: 30
+    rechargeDuration: 12.5
 
 - type: entity
   name: abductor's wirecutter


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Уменьшил воссталовление зарядов рсу CE.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Самый худший хайриск. Буквально обычный РСУ будет лучше, чем у главы отдела.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: worstplayerever
- tweak: Изменено  РСУ Старшего Инженера. Восстановление одного заряду РСУ 30s -> 15s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Улучшения
  - Сокращено время авто‑перезарядки продвинутого строительного инструмента: с 30 до 15 секунд. Теперь инструмент быстрее готов к следующему применению, что ускоряет работу и снижает простои в активных задачах. Поведение и остальные характеристики инструмента не изменились; изменение касается только интервала восстановления между использованиями. Изменение заметно в повседневном использовании и не требует действий со стороны пользователя.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->