### PR TITLE
Бафф пожарного топора синди

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -60,7 +60,7 @@
   - type: MeleeWeapon
     wideAnimationRotation: 90
   - type: IgniteOnMeleeHit
-    fireStacks: 1
+    fireStacks: 2
   - type: Sprite
     sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     state: icon
@@ -70,3 +70,10 @@
     slots:
     - back
     - suitStorage  # Sunrise-Fireaxe
+  - type: Reflect
+    reflectProb: 0.25
+    spread: 180
+    soundOnReflect: /Audio/_Starlight/Armor/Ricochet/ricochet1_1.ogg
+    reflects:
+    - NonEnergy
+    - Energy

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -59,8 +59,26 @@
   components:
   - type: MeleeWeapon
     wideAnimationRotation: 90
+    #Sunrise-start
   - type: IgniteOnMeleeHit
-    fireStacks: 2
+    fireStacks: 3
+  - type: MeleeWeapon
+    wideAnimationRotation: 135
+    swingLeft: true
+    attackRate: 0.75
+    damage:
+      types:
+        Blunt: 5
+        Slash: 10
+        Structural: 10
+    soundHit:
+      collection: MetalThud
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Slash: 15
+        Structural: 50
+    #Sunrise-end
   - type: Sprite
     sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     state: icon
@@ -70,10 +88,3 @@
     slots:
     - back
     - suitStorage  # Sunrise-Fireaxe
-  - type: Reflect
-    reflectProb: 0.25
-    spread: 180
-    soundOnReflect: /Audio/_Starlight/Armor/Ricochet/ricochet1_1.ogg
-    reflects:
-    - NonEnergy
-    - Energy


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Пожарный топор синди получил +5 урона порезами, +10 урона по структурам и тройную силу поджога. Теперь он будет более привлекательной покупкой.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: Alexnov33X
- tweak: Пожарный топор синди получил +5 урона порезами, +10 урона по структурам и тройную силу поджога. Теперь он будет более привлекательной покупкой.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Новые возможности
  - Пылающий пожарный топор получил обновлённую механику удара: более широкий замах, смещение влево, ускоренная частота атак и новый звук попадания (металлический стук).

- Баланс
  - Усилен урон при владении (значительно повышен эффект по типам урона).
  - Увеличено накопление огня при попадании: теперь накладывается 3 стака огня (ранее 1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->