### PR TITLE
Removing alert in aghost

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -90,6 +90,7 @@
     followEntity: true
   - type: CargoOrderConsole
   - type: CrewMonitoringConsole
+    doCorpseAlert: false
   - type: GeneralStationRecordConsole
     canDeleteEntries: true
   - type: DeviceNetwork


### PR DESCRIPTION
## Кратное описание
Временно убрать оповещение мониторинга персонала в aghost
## По какой причине
Не имеет смысла включать его, пока не будет системы переключения состояния
https://github.com/space-sunrise/sunrise-station/issues/3046