### PR TITLE
NO TTS for cryo and latejoin announcements

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -244,7 +244,8 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
                 ("entity", ent.Owner), // gender things for supporting downstreams with other languages
                 ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))
             ), Loc.GetString("earlyleave-cryo-sender"),
-            playDefault: false
+            playDefault: false,
+            playTts: false
         );
     }
 

--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -237,16 +237,16 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             _stationRecords.RemoveRecord(key, stationRecords);
         }
 
-        _chatSystem.DispatchStationAnnouncement(station.Value,
-            Loc.GetString(
-                "earlyleave-cryo-announcement",
-                ("character", name),
-                ("entity", ent.Owner), // gender things for supporting downstreams with other languages
-                ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))
-            ), Loc.GetString("earlyleave-cryo-sender"),
-            playDefault: false,
-            playTts: false
-        );
+        // _chatSystem.DispatchStationAnnouncement(station.Value,
+        //     Loc.GetString(
+        //         "earlyleave-cryo-announcement",
+        //         ("character", name),
+        //         ("entity", ent.Owner), // gender things for supporting downstreams with other languages
+        //         ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))
+        //     ), Loc.GetString("earlyleave-cryo-sender"),
+        //     playDefault: false,
+        //     playTts: false
+        // );
     }
 
     private void HandleCryostorageReconnection(Entity<CryostorageContainedComponent> entity)

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -330,18 +330,18 @@ namespace Content.Server.GameTicking
                         playDefault: false,
                         colorOverride: Color.Gold);
                 }
-                else
-                {
-                    _chatSystem.DispatchStationAnnouncement(station,
-                        Loc.GetString("latejoin-arrival-announcement",
-                            ("character", MetaData(mob).EntityName),
-                            ("gender", character.Gender), // Russian-LastnameGender
-                            ("entity", mob),
-                            ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))),
-                        Loc.GetString("latejoin-arrival-sender"),
-                        playDefault: false,
-                        playTts: false);
-                }
+                // else
+                // {
+                //     _chatSystem.DispatchStationAnnouncement(station,
+                //         Loc.GetString("latejoin-arrival-announcement",
+                //             ("character", MetaData(mob).EntityName),
+                //             ("gender", character.Gender), // Russian-LastnameGender
+                //             ("entity", mob),
+                //             ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))),
+                //         Loc.GetString("latejoin-arrival-sender"),
+                //         playDefault: false,
+                //         playTts: false);
+                // }
             }
 
             if (player.UserId == new Guid("{e887eb93-f503-4b65-95b6-2f282c014192}"))

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -339,7 +339,8 @@ namespace Content.Server.GameTicking
                             ("entity", mob),
                             ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))),
                         Loc.GetString("latejoin-arrival-sender"),
-                        playDefault: false);
+                        playDefault: false,
+                        playTts: false);
                 }
             }
 


### PR DESCRIPTION
:cl: SplikZerys
- remove: Удалены оповешения прибытия и ухода в крио.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Исправления ошибок
  * Оповещения при помещении персонажа в криохранилище больше не озвучиваются синтезом речи; отображается только текст.
  * Сообщения о позднем присоединении игроков также отключают синтез речи, исключая голосовое воспроизведение.
  * Это уменьшает навязчивые голосовые уведомления и делает работу станционной системы оповещений более предсказуемой и комфортной для игроков.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->